### PR TITLE
fix: send emails directly to Sent, no draft left behind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.4.1] - 2026-01-11
+
+### Fixed
+
+- Sending emails no longer leaves a draft behind - emails are created directly in Sent folder
+
 ## [1.4.0] - 2026-01-11
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fastmail-cli"
-version = "1.4.0"
+version = "1.4.1"
 edition = "2024"
 description = "CLI for Fastmail's JMAP API"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # fastmail-cli
 
-CLI for Fastmail's JMAP API. Read, search, send, and manage emails from your terminal.
+CLI for Fastmail's JMAP API. Read, search, send, and manage emails from your terminal or AI assistant.
 
 ## Features
 


### PR DESCRIPTION
Fixes issue where sending emails via CLI or MCP would leave a draft in the Drafts folder.

**Before:** Email/set created draft in Drafts → EmailSubmission/set sent it → onSuccessUpdateEmail tried to move to Sent (but draft remained)

**After:** Email/set creates directly in Sent → EmailSubmission/set sends it → onSuccessUpdateEmail just marks as $seen

Affects: `send`, `reply`, `forward` commands and their MCP equivalents.