### PR TITLE
feat: add contacts support via CardDAV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [1.5.0] - 2026-01-11
+
+### Added
+
+- Contacts support via CardDAV (`contacts list`, `contacts search`)
+- `search_contacts` MCP tool for Claude to look up email addresses by name
+- `FASTMAIL_USERNAME` and `FASTMAIL_APP_PASSWORD` env vars for CardDAV auth
+
+### Notes
+
+- CardDAV requires an app password - Fastmail's API tokens only work for JMAP
+- Generate app password at Fastmail Settings > Privacy & Security > Integrations > App passwords
+
 ## [1.4.1] - 2026-01-11
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fastmail-cli"
-version = "1.4.1"
+version = "1.5.0"
 edition = "2024"
 description = "CLI for Fastmail's JMAP API"
 license = "MIT"
@@ -18,6 +18,7 @@ dirs = "6.0.0"
 docx-lite = "0.2.0"
 image = { version = "0.25", default-features = false, features = ["jpeg", "png", "gif", "webp"] }
 pdf-extract = "0.10.0"
+vcard = "0.4"
 reqwest = { version = "0.13.1", default-features = false, features = ["json", "rustls"] }
 rmcp = { version = "0.12", features = ["server", "transport-io"] }
 schemars = "0.8"

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ CLI for Fastmail's JMAP API. Read, search, send, and manage emails from your ter
 | --------------------- | ------------------------------------------------- |
 | **Email**             | List, search, read, send, reply, forward, threads |
 | **Mailboxes**         | List folders, move emails, mark spam/read         |
+| **Contacts**          | Search contacts via CardDAV                       |
 | **Attachments**       | Download files, extract text, resize images       |
 | **Text Extraction**   | PDF, DOCX (pure Rust), DOC (textutil)             |
 | **Image Resizing**    | `--max-size` to resize images on download         |
@@ -206,6 +207,24 @@ fastmail-cli completions zsh >> ~/.zshrc
 fastmail-cli completions fish > ~/.config/fish/completions/fastmail-cli.fish
 ```
 
+### Contacts
+
+Search your Fastmail contacts via CardDAV. Requires an app password (API tokens don't work for CardDAV).
+
+```bash
+# Set credentials
+export FASTMAIL_USERNAME="you@fastmail.com"
+export FASTMAIL_APP_PASSWORD="your-app-password"
+
+# List all contacts
+fastmail-cli contacts list
+
+# Search by name, email, or organization
+fastmail-cli contacts search "alice"
+```
+
+Generate an app password at [Fastmail Settings > Privacy & Security > Integrations > App passwords](https://app.fastmail.com/settings/security/devicekeys).
+
 ### Masked Email
 
 Create disposable email addresses for signups. Requires Fastmail's masked email feature.
@@ -271,19 +290,24 @@ Configure in Claude Desktop's `claude_desktop_config.json`:
       "command": "fastmail-cli",
       "args": ["mcp"],
       "env": {
-        "FASTMAIL_API_TOKEN": "your-token-here"
+        "FASTMAIL_API_TOKEN": "your-token-here",
+        "FASTMAIL_USERNAME": "you@fastmail.com",
+        "FASTMAIL_APP_PASSWORD": "your-app-password"
       }
     }
   }
 }
 ```
 
-The MCP server exposes 16 tools for email operations:
+Username and app password are optional - only needed for contact search (CardDAV requires app password, API tokens don't work).
+
+The MCP server exposes 17 tools for email operations:
 
 - **Reading**: `list_mailboxes`, `list_emails`, `get_email`, `search_emails`
 - **Actions**: `move_email`, `mark_as_read`, `mark_as_spam`
 - **Sending**: `send_email`, `reply_to_email`, `forward_email` (preview/confirm flow)
 - **Attachments**: `list_attachments`, `get_attachment` (auto text extraction, image resizing)
+- **Contacts**: `search_contacts` (requires app password)
 - **Masked Email**: `list_masked_emails`, `create_masked_email`, `enable_masked_email`, `disable_masked_email`, `delete_masked_email`
 
 Token can be set via `FASTMAIL_API_TOKEN` env var or config file.

--- a/src/carddav/mod.rs
+++ b/src/carddav/mod.rs
@@ -1,0 +1,329 @@
+//! CardDAV client for Fastmail contacts
+//!
+//! Uses raw HTTP with reqwest since CardDAV is just WebDAV with vCard.
+
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use tracing::{debug, instrument};
+
+use crate::error::{Error, Result};
+
+const CARDDAV_BASE: &str = "https://carddav.fastmail.com";
+
+/// A contact parsed from vCard
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Contact {
+    /// Unique ID (from UID property)
+    pub id: String,
+    /// Full name (FN property)
+    pub name: String,
+    /// Email addresses
+    pub emails: Vec<ContactEmail>,
+    /// Phone numbers
+    pub phones: Vec<ContactPhone>,
+    /// Organization/company
+    pub organization: Option<String>,
+    /// Job title
+    pub title: Option<String>,
+    /// Notes
+    pub notes: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ContactEmail {
+    pub email: String,
+    pub label: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ContactPhone {
+    pub number: String,
+    pub label: Option<String>,
+}
+
+/// Address book info
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AddressBook {
+    pub href: String,
+    pub name: String,
+}
+
+/// CardDAV client
+pub struct CardDavClient {
+    client: Client,
+    username: String,
+    app_password: String,
+}
+
+impl CardDavClient {
+    pub fn new(username: String, app_password: String) -> Self {
+        Self {
+            client: Client::new(),
+            username,
+            app_password,
+        }
+    }
+
+    /// Discover address books for the user
+    #[instrument(skip(self))]
+    pub async fn list_addressbooks(&self) -> Result<Vec<AddressBook>> {
+        let url = format!("{}/dav/addressbooks/user/{}/", CARDDAV_BASE, self.username);
+
+        let body = r#"<?xml version="1.0" encoding="utf-8"?>
+<d:propfind xmlns:d="DAV:" xmlns:card="urn:ietf:params:xml:ns:carddav">
+  <d:prop>
+    <d:displayname/>
+    <d:resourcetype/>
+  </d:prop>
+</d:propfind>"#;
+
+        let response = self
+            .client
+            .request(reqwest::Method::from_bytes(b"PROPFIND").unwrap(), &url)
+            .basic_auth(&self.username, Some(&self.app_password))
+            .header("Content-Type", "application/xml")
+            .header("Depth", "1")
+            .body(body)
+            .send()
+            .await?;
+
+        let status = response.status();
+        let text: String = response.text().await?;
+
+        debug!(status = %status, "PROPFIND response");
+
+        if !status.is_success() && status.as_u16() != 207 {
+            return Err(Error::Server(format!(
+                "CardDAV PROPFIND failed: {} - {}",
+                status, text
+            )));
+        }
+
+        // Parse the multistatus XML response
+        self.parse_addressbooks_response(&text)
+    }
+
+    fn parse_addressbooks_response(&self, xml: &str) -> Result<Vec<AddressBook>> {
+        let mut addressbooks = Vec::new();
+
+        // Simple XML parsing - look for response elements with addressbook resourcetype
+        for response in xml.split("<d:response>").skip(1) {
+            let href = extract_xml_value(response, "d:href").unwrap_or_default();
+            let displayname = extract_xml_value(response, "d:displayname");
+
+            // Check if this is an addressbook (has carddav:addressbook resourcetype)
+            if response.contains("addressbook") && !href.is_empty() {
+                let name = displayname.unwrap_or_else(|| {
+                    href.split('/')
+                        .filter(|s| !s.is_empty())
+                        .last()
+                        .unwrap_or("Unknown")
+                        .to_string()
+                });
+
+                // Skip the parent collection itself
+                if !href.ends_with(&format!("{}/", self.username)) {
+                    addressbooks.push(AddressBook { href, name });
+                }
+            }
+        }
+
+        Ok(addressbooks)
+    }
+
+    /// List all contacts in an address book
+    #[instrument(skip(self))]
+    pub async fn list_contacts(&self, addressbook_href: &str) -> Result<Vec<Contact>> {
+        let url = format!("{}{}", CARDDAV_BASE, addressbook_href);
+
+        let body = r#"<?xml version="1.0" encoding="utf-8"?>
+<card:addressbook-query xmlns:d="DAV:" xmlns:card="urn:ietf:params:xml:ns:carddav">
+  <d:prop>
+    <d:getetag/>
+    <card:address-data/>
+  </d:prop>
+</card:addressbook-query>"#;
+
+        let response = self
+            .client
+            .request(reqwest::Method::from_bytes(b"REPORT").unwrap(), &url)
+            .basic_auth(&self.username, Some(&self.app_password))
+            .header("Content-Type", "application/xml")
+            .header("Depth", "1")
+            .body(body)
+            .send()
+            .await?;
+
+        let status = response.status();
+        let text: String = response.text().await?;
+
+        debug!(status = %status, "REPORT response");
+
+        if !status.is_success() && status.as_u16() != 207 {
+            return Err(Error::Server(format!(
+                "CardDAV REPORT failed: {} - {}",
+                status, text
+            )));
+        }
+
+        self.parse_contacts_response(&text)
+    }
+
+    fn parse_contacts_response(&self, xml: &str) -> Result<Vec<Contact>> {
+        let mut contacts = Vec::new();
+
+        for response in xml.split("<d:response>").skip(1) {
+            if let Some(vcard_data) = extract_xml_value(response, "card:address-data") {
+                // Unescape XML entities
+                let vcard_data = vcard_data
+                    .replace("&lt;", "<")
+                    .replace("&gt;", ">")
+                    .replace("&amp;", "&")
+                    .replace("&quot;", "\"");
+
+                if let Some(contact) = parse_vcard(&vcard_data) {
+                    contacts.push(contact);
+                }
+            }
+        }
+
+        // Sort by name
+        contacts.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+
+        Ok(contacts)
+    }
+
+    /// Search contacts by name or email
+    pub async fn search_contacts(&self, query: &str) -> Result<Vec<Contact>> {
+        // Get all contacts from all addressbooks and filter
+        let addressbooks = self.list_addressbooks().await?;
+        let mut all_contacts = Vec::new();
+
+        for ab in addressbooks {
+            let contacts = self.list_contacts(&ab.href).await?;
+            all_contacts.extend(contacts);
+        }
+
+        let query_lower = query.to_lowercase();
+        let filtered: Vec<Contact> = all_contacts
+            .into_iter()
+            .filter(|c| {
+                c.name.to_lowercase().contains(&query_lower)
+                    || c.emails
+                        .iter()
+                        .any(|e| e.email.to_lowercase().contains(&query_lower))
+                    || c.organization
+                        .as_ref()
+                        .is_some_and(|o| o.to_lowercase().contains(&query_lower))
+            })
+            .collect();
+
+        Ok(filtered)
+    }
+}
+
+/// Extract value between XML tags (simple, non-recursive)
+fn extract_xml_value(xml: &str, tag: &str) -> Option<String> {
+    let open_tag = format!("<{}", tag);
+    let close_tag = format!("</{}>", tag);
+
+    let start = xml.find(&open_tag)?;
+    let after_open = &xml[start..];
+
+    // Find end of opening tag
+    let tag_end = after_open.find('>')?;
+    let content_start = start + tag_end + 1;
+
+    // Find closing tag
+    let close_start = xml[content_start..].find(&close_tag)?;
+
+    Some(
+        xml[content_start..content_start + close_start]
+            .trim()
+            .to_string(),
+    )
+}
+
+/// Parse a vCard string into a Contact
+fn parse_vcard(vcard_str: &str) -> Option<Contact> {
+    // Simple manual vCard parsing since the vcard crate API is awkward
+    let mut id = String::new();
+    let mut name = String::new();
+    let mut emails = Vec::new();
+    let mut phones = Vec::new();
+    let mut organization = None;
+    let mut title = None;
+    let mut notes = None;
+
+    for line in vcard_str.lines() {
+        let line = line.trim();
+
+        if line.starts_with("UID:") {
+            id = line.strip_prefix("UID:").unwrap_or("").to_string();
+        } else if line.starts_with("FN:") {
+            name = line.strip_prefix("FN:").unwrap_or("").to_string();
+        } else if line.starts_with("EMAIL") {
+            // EMAIL;TYPE=work:bob@example.com or EMAIL:bob@example.com
+            let label = if line.contains("TYPE=") {
+                line.split("TYPE=")
+                    .nth(1)
+                    .and_then(|s| s.split(':').next())
+                    .map(|s| s.to_string())
+            } else {
+                None
+            };
+            let email = line.split(':').last().unwrap_or("").to_string();
+            if !email.is_empty() {
+                emails.push(ContactEmail { email, label });
+            }
+        } else if line.starts_with("TEL") {
+            let label = if line.contains("TYPE=") {
+                line.split("TYPE=")
+                    .nth(1)
+                    .and_then(|s| s.split(':').next())
+                    .or_else(|| line.split("TYPE=").nth(1).and_then(|s| s.split(';').next()))
+                    .map(|s| s.to_string())
+            } else {
+                None
+            };
+            let number = line.split(':').last().unwrap_or("").to_string();
+            if !number.is_empty() {
+                phones.push(ContactPhone { number, label });
+            }
+        } else if line.starts_with("ORG:") {
+            organization = Some(line.strip_prefix("ORG:").unwrap_or("").to_string());
+        } else if line.starts_with("TITLE:") {
+            title = Some(line.strip_prefix("TITLE:").unwrap_or("").to_string());
+        } else if line.starts_with("NOTE:") {
+            notes = Some(line.strip_prefix("NOTE:").unwrap_or("").to_string());
+        }
+    }
+
+    // Need at least a name
+    if name.is_empty() {
+        return None;
+    }
+
+    // Generate ID if not present
+    if id.is_empty() {
+        id = format!("{:x}", md5_hash(&name));
+    }
+
+    Some(Contact {
+        id,
+        name,
+        emails,
+        phones,
+        organization,
+        title,
+        notes,
+    })
+}
+
+/// Simple hash for generating IDs
+fn md5_hash(s: &str) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    s.hash(&mut hasher);
+    hasher.finish()
+}

--- a/src/commands/contacts.rs
+++ b/src/commands/contacts.rs
@@ -1,0 +1,38 @@
+use crate::carddav::CardDavClient;
+use crate::config::Config;
+use crate::models::Output;
+
+/// List all contacts from all address books
+pub async fn list_contacts() -> anyhow::Result<()> {
+    let config = Config::load()?;
+    let username = config.get_username()?;
+    let app_password = config.get_app_password()?;
+
+    let client = CardDavClient::new(username, app_password);
+
+    let addressbooks = client.list_addressbooks().await?;
+    eprintln!("Found {} address book(s)", addressbooks.len());
+
+    let mut all_contacts = Vec::new();
+    for ab in &addressbooks {
+        eprintln!("Fetching from: {}", ab.name);
+        let contacts = client.list_contacts(&ab.href).await?;
+        all_contacts.extend(contacts);
+    }
+
+    Output::success(all_contacts).print();
+    Ok(())
+}
+
+/// Search contacts by name or email
+pub async fn search_contacts(query: &str) -> anyhow::Result<()> {
+    let config = Config::load()?;
+    let username = config.get_username()?;
+    let app_password = config.get_app_password()?;
+
+    let client = CardDavClient::new(username, app_password);
+    let contacts = client.search_contacts(query).await?;
+
+    Output::success(contacts).print();
+    Ok(())
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,4 +1,5 @@
 mod auth;
+mod contacts;
 mod download;
 mod forward;
 mod get;
@@ -13,6 +14,7 @@ mod spam;
 mod thread;
 
 pub use auth::*;
+pub use contacts::*;
 pub use download::*;
 pub use forward::*;
 pub use get::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod carddav;
 mod commands;
 mod config;
 mod error;
@@ -241,6 +242,10 @@ enum Commands {
     #[command(subcommand)]
     Masked(MaskedCommands),
 
+    /// Manage contacts via CardDAV
+    #[command(subcommand)]
+    Contacts(ContactsCommands),
+
     /// Run as MCP (Model Context Protocol) server for Claude integration
     Mcp,
 }
@@ -302,6 +307,18 @@ enum ListCommands {
         /// Maximum results
         #[arg(short, long, default_value = "50")]
         limit: u32,
+    },
+}
+
+#[derive(Subcommand)]
+enum ContactsCommands {
+    /// List all contacts
+    List,
+
+    /// Search contacts by name or email
+    Search {
+        /// Search query
+        query: String,
     },
 }
 
@@ -462,6 +479,11 @@ async fn main() {
                 }
                 commands::delete_masked_email(&id).await
             }
+        },
+
+        Commands::Contacts(cmd) => match cmd {
+            ContactsCommands::List => commands::list_contacts().await,
+            ContactsCommands::Search { query } => commands::search_contacts(&query).await,
         },
 
         Commands::Mcp => mcp::run_server().await,

--- a/src/mcp/format.rs
+++ b/src/mcp/format.rs
@@ -1,5 +1,6 @@
 //! Formatting helpers for MCP tool output
 
+use crate::carddav::Contact;
 use crate::models::{Email, EmailAddress, Mailbox, MaskedEmail};
 
 pub fn format_address(addr: &EmailAddress) -> String {
@@ -123,6 +124,61 @@ pub fn format_masked_email(m: &MaskedEmail) -> String {
     }
     if let Some(ref created) = m.created_at {
         lines.push(format!("Created: {}", created));
+    }
+
+    lines.join("\n")
+}
+
+pub fn format_contact(c: &Contact) -> String {
+    let mut lines = vec![format!("**{}**", c.name)];
+
+    if !c.emails.is_empty() {
+        let emails: Vec<String> = c
+            .emails
+            .iter()
+            .map(|e| {
+                let label = e
+                    .label
+                    .as_ref()
+                    .map(|l| l.trim_end_matches(';').to_lowercase())
+                    .filter(|l| !l.is_empty())
+                    .map(|l| format!(" ({})", l))
+                    .unwrap_or_default();
+                format!("  {}{}", e.email, label)
+            })
+            .collect();
+        lines.push(format!("Emails:\n{}", emails.join("\n")));
+    }
+
+    if !c.phones.is_empty() {
+        let phones: Vec<String> = c
+            .phones
+            .iter()
+            .map(|p| {
+                let label = p
+                    .label
+                    .as_ref()
+                    .map(|l| l.trim_end_matches(';').to_lowercase())
+                    .filter(|l| !l.is_empty())
+                    .map(|l| format!(" ({})", l))
+                    .unwrap_or_default();
+                format!("  {}{}", p.number, label)
+            })
+            .collect();
+        lines.push(format!("Phones:\n{}", phones.join("\n")));
+    }
+
+    if let Some(ref org) = c.organization {
+        let org = org.trim_end_matches(';').trim();
+        if !org.is_empty() {
+            lines.push(format!("Organization: {}", org));
+        }
+    }
+
+    if let Some(ref title) = c.title {
+        if !title.is_empty() {
+            lines.push(format!("Title: {}", title));
+        }
     }
 
     lines.join("\n")


### PR DESCRIPTION
## Summary

Adds contact search via CardDAV for looking up email addresses by name.

## Changes

- `contacts list` - list all contacts from all address books
- `contacts search <query>` - search by name, email, or organization  
- `search_contacts` MCP tool for Claude integration

## Auth

CardDAV requires an app password (API tokens only work for JMAP). New env vars:

- `FASTMAIL_USERNAME` - your email address
- `FASTMAIL_APP_PASSWORD` - app password from Fastmail settings

## Why

Lets Claude do things like "send email to Sarita" instead of requiring full email addresses.

---

v1.5.0 release