### PR TITLE
feat: add --from identity selection for send, reply, and forward

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,14 @@ fastmail-cli search --from "boss" --has-attachment --after 2024-06-01 --limit 20
 
 Available flags: `--text`, `--from`, `--to`, `--cc`, `--bcc`, `--subject`, `--body`, `--mailbox`, `--has-attachment`, `--min-size`, `--max-size`, `--before`, `--after`, `--unread`, `--flagged`
 
+### List Identities
+
+List all sender identities (email addresses) on your account. Useful for finding valid addresses for `--from`.
+
+```bash
+fastmail-cli list identities
+```
+
 ### Send Email
 
 ```bash
@@ -144,6 +152,13 @@ fastmail-cli send \
   --to "alice@example.com" \
   --cc "bob@example.com" \
   --bcc "secret@example.com" \
+  --subject "Hello" \
+  --body "Message"
+
+# Send from a specific identity
+fastmail-cli send \
+  --from "alias@example.com" \
+  --to "alice@example.com" \
   --subject "Hello" \
   --body "Message"
 ```
@@ -214,6 +229,9 @@ fastmail-cli reply EMAIL_ID --body "Thanks everyone" --all
 
 # Reply with additional CC/BCC
 fastmail-cli reply EMAIL_ID --body "Response" --cc "boss@example.com"
+
+# Reply from a specific identity
+fastmail-cli reply EMAIL_ID --body "Response" --from "alias@example.com"
 ```
 
 ### Forward Email
@@ -222,6 +240,12 @@ fastmail-cli reply EMAIL_ID --body "Response" --cc "boss@example.com"
 fastmail-cli forward EMAIL_ID \
   --to "colleague@example.com" \
   --body "FYI - see below"
+
+# Forward from a specific identity
+fastmail-cli forward EMAIL_ID \
+  --to "colleague@example.com" \
+  --body "FYI" \
+  --from "alias@example.com"
 ```
 
 ### Shell Completions
@@ -331,11 +355,12 @@ Configure in Claude Desktop's `claude_desktop_config.json`:
 
 Username and app password are optional - only needed for contact search (CardDAV requires app password, API tokens don't work).
 
-The MCP server exposes 17 tools for email operations:
+The MCP server exposes 18 tools for email operations:
 
 - **Reading**: `list_mailboxes`, `list_emails`, `get_email`, `search_emails`
+- **Identity**: `list_identities` (discover available sender addresses for `from` parameter)
 - **Actions**: `move_email`, `mark_as_read`, `mark_as_spam`
-- **Sending**: `send_email`, `reply_to_email`, `forward_email` (preview/confirm flow)
+- **Sending**: `send_email`, `reply_to_email`, `forward_email` (preview/confirm flow, optional `from` for identity selection)
 - **Attachments**: `list_attachments`, `get_attachment` (auto text extraction, image resizing)
 - **Contacts**: `search_contacts` (requires app password)
 - **Masked Email**: `list_masked_emails`, `create_masked_email`, `enable_masked_email`, `disable_masked_email`, `delete_masked_email`

--- a/src/commands/forward.rs
+++ b/src/commands/forward.rs
@@ -9,6 +9,7 @@ pub async fn forward(
     body: &str,
     cc: Option<&str>,
     bcc: Option<&str>,
+    from: Option<&str>,
 ) -> anyhow::Result<()> {
     let config = Config::load()?;
     let token = config.get_token()?;
@@ -23,7 +24,7 @@ pub async fn forward(
     let bcc_addrs = bcc.map(parse_addresses).unwrap_or_default();
 
     let new_email_id = client
-        .forward_email(&original, to_addrs, body, cc_addrs, bcc_addrs)
+        .forward_email(&original, to_addrs, body, cc_addrs, bcc_addrs, from)
         .await?;
 
     #[derive(serde::Serialize)]

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -35,3 +35,16 @@ pub async fn list_emails(mailbox: &str, limit: u32) -> anyhow::Result<()> {
 
     Ok(())
 }
+
+pub async fn list_identities() -> anyhow::Result<()> {
+    let config = Config::load()?;
+    let token = config.get_token()?;
+
+    let mut client = JmapClient::new(token.to_string());
+    client.authenticate().await?;
+
+    let identities = client.list_identities().await?;
+    Output::success(identities).print();
+
+    Ok(())
+}

--- a/src/commands/reply.rs
+++ b/src/commands/reply.rs
@@ -9,6 +9,7 @@ pub async fn reply(
     reply_all: bool,
     cc: Option<&str>,
     bcc: Option<&str>,
+    from: Option<&str>,
 ) -> anyhow::Result<()> {
     let config = Config::load()?;
     let token = config.get_token()?;
@@ -22,7 +23,7 @@ pub async fn reply(
     let bcc_addrs = bcc.map(parse_addresses).unwrap_or_default();
 
     let new_email_id = client
-        .reply_email(&original, body, reply_all, cc_addrs, bcc_addrs)
+        .reply_email(&original, body, reply_all, cc_addrs, bcc_addrs, from)
         .await?;
 
     #[derive(serde::Serialize)]

--- a/src/commands/send.rs
+++ b/src/commands/send.rs
@@ -37,6 +37,7 @@ pub async fn send(
     cc: Option<&str>,
     bcc: Option<&str>,
     reply_to: Option<&str>,
+    from: Option<&str>,
 ) -> anyhow::Result<()> {
     let config = Config::load()?;
     let token = config.get_token()?;
@@ -49,7 +50,7 @@ pub async fn send(
     let bcc_addrs = bcc.map(parse_addresses).unwrap_or_default();
 
     let email_id = client
-        .send_email(to_addrs, cc_addrs, bcc_addrs, subject, body, reply_to)
+        .send_email(to_addrs, cc_addrs, bcc_addrs, subject, body, reply_to, from)
         .await?;
 
     #[derive(serde::Serialize)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -33,6 +33,9 @@ pub enum Error {
     #[error("Identity not found for sending")]
     IdentityNotFound,
 
+    #[error("No identity found matching '{0}'. Run `fastmail-cli list identities` to see available identities.")]
+    IdentityNotFoundForEmail(String),
+
     #[error("Config error: {0}")]
     Config(String),
 

--- a/src/jmap/mod.rs
+++ b/src/jmap/mod.rs
@@ -517,6 +517,21 @@ impl JmapClient {
         Ok(resp.list)
     }
 
+    /// Resolve an identity by email address, or return the default (first) identity.
+    async fn resolve_identity(&self, from: Option<&str>) -> Result<Identity> {
+        let identities = self.list_identities().await?;
+        match from {
+            Some(email) => identities
+                .into_iter()
+                .find(|i| i.email.eq_ignore_ascii_case(email))
+                .ok_or_else(|| Error::IdentityNotFoundForEmail(email.to_string())),
+            None => identities
+                .into_iter()
+                .next()
+                .ok_or(Error::IdentityNotFound),
+        }
+    }
+
     #[instrument(skip(self, body))]
     pub async fn send_email(
         &self,
@@ -526,14 +541,14 @@ impl JmapClient {
         subject: &str,
         body: &str,
         in_reply_to: Option<&str>,
+        from: Option<&str>,
     ) -> Result<String> {
         let account_id = self
             .session()?
             .primary_account_id()
             .ok_or_else(|| Error::Config("No primary account".into()))?;
 
-        let identities = self.list_identities().await?;
-        let identity = identities.first().ok_or(Error::IdentityNotFound)?;
+        let identity = self.resolve_identity(from).await?;
 
         let sent = self.find_mailbox("sent").await?;
 
@@ -765,14 +780,14 @@ impl JmapClient {
         reply_all: bool,
         cc: Vec<EmailAddress>,
         bcc: Vec<EmailAddress>,
+        from: Option<&str>,
     ) -> Result<String> {
         let account_id = self
             .session()?
             .primary_account_id()
             .ok_or_else(|| Error::Config("No primary account".into()))?;
 
-        let identities = self.list_identities().await?;
-        let identity = identities.first().ok_or(Error::IdentityNotFound)?;
+        let identity = self.resolve_identity(from).await?;
         let my_email = identity.email.to_lowercase();
 
         let sent = self.find_mailbox("sent").await?;
@@ -966,14 +981,14 @@ impl JmapClient {
         body: &str,
         cc: Vec<EmailAddress>,
         bcc: Vec<EmailAddress>,
+        from: Option<&str>,
     ) -> Result<String> {
         let account_id = self
             .session()?
             .primary_account_id()
             .ok_or_else(|| Error::Config("No primary account".into()))?;
 
-        let identities = self.list_identities().await?;
-        let identity = identities.first().ok_or(Error::IdentityNotFound)?;
+        let identity = self.resolve_identity(from).await?;
 
         let sent = self.find_mailbox("sent").await?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -137,6 +137,10 @@ enum Commands {
         /// In-Reply-To message ID (for threading)
         #[arg(long)]
         reply_to: Option<String>,
+
+        /// Send from a specific identity (email address). Use `list identities` to see available.
+        #[arg(long)]
+        from: Option<String>,
     },
 
     /// Move email to a mailbox
@@ -207,6 +211,10 @@ enum Commands {
         /// BCC recipient(s), comma-separated
         #[arg(long)]
         bcc: Option<String>,
+
+        /// Send from a specific identity (email address). Use `list identities` to see available.
+        #[arg(long)]
+        from: Option<String>,
     },
 
     /// Forward an email
@@ -229,6 +237,10 @@ enum Commands {
         /// BCC recipient(s), comma-separated
         #[arg(long)]
         bcc: Option<String>,
+
+        /// Send from a specific identity (email address). Use `list identities` to see available.
+        #[arg(long)]
+        from: Option<String>,
     },
 
     /// Generate shell completions
@@ -308,6 +320,9 @@ enum ListCommands {
         #[arg(short, long, default_value = "50")]
         limit: u32,
     },
+
+    /// List sender identities (for use with --from)
+    Identities,
 }
 
 #[derive(Subcommand)]
@@ -337,6 +352,7 @@ async fn main() {
         Commands::List(cmd) => match cmd {
             ListCommands::Mailboxes => commands::list_mailboxes().await,
             ListCommands::Emails { mailbox, limit } => commands::list_emails(&mailbox, limit).await,
+            ListCommands::Identities => commands::list_identities().await,
         },
 
         Commands::Get { email_id } => commands::get_email(&email_id).await,
@@ -391,6 +407,7 @@ async fn main() {
             cc,
             bcc,
             reply_to,
+            from,
         } => {
             commands::send(
                 &to,
@@ -399,6 +416,7 @@ async fn main() {
                 cc.as_deref(),
                 bcc.as_deref(),
                 reply_to.as_deref(),
+                from.as_deref(),
             )
             .await
         }
@@ -436,7 +454,8 @@ async fn main() {
             all,
             cc,
             bcc,
-        } => commands::reply(&email_id, &body, all, cc.as_deref(), bcc.as_deref()).await,
+            from,
+        } => commands::reply(&email_id, &body, all, cc.as_deref(), bcc.as_deref(), from.as_deref()).await,
 
         Commands::Forward {
             email_id,
@@ -444,7 +463,8 @@ async fn main() {
             body,
             cc,
             bcc,
-        } => commands::forward(&email_id, &to, &body, cc.as_deref(), bcc.as_deref()).await,
+            from,
+        } => commands::forward(&email_id, &to, &body, cc.as_deref(), bcc.as_deref(), from.as_deref()).await,
 
         Commands::Completions { shell } => {
             generate(

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -124,6 +124,9 @@ pub struct SendEmailRequest {
     /// BCC recipients (hidden), comma-separated
     #[serde(default)]
     pub bcc: Option<String>,
+    /// Send from a specific identity/email address. Optional - uses default identity if not specified.
+    #[serde(default)]
+    pub from: Option<String>,
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
@@ -143,6 +146,9 @@ pub struct ReplyEmailRequest {
     /// BCC recipients (hidden), comma-separated
     #[serde(default)]
     pub bcc: Option<String>,
+    /// Send from a specific identity/email address. Optional - uses default identity if not specified.
+    #[serde(default)]
+    pub from: Option<String>,
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
@@ -162,6 +168,9 @@ pub struct ForwardEmailRequest {
     /// BCC recipients (hidden), comma-separated
     #[serde(default)]
     pub bcc: Option<String>,
+    /// Send from a specific identity/email address. Optional - uses default identity if not specified.
+    #[serde(default)]
+    pub from: Option<String>,
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
@@ -270,6 +279,41 @@ impl FastmailMcp {
                 Self::text_result(text)
             }
             Err(e) => Self::error_result(format!("Failed to list mailboxes: {}", e)),
+        }
+    }
+
+    #[tool(
+        description = "List all sender identities on the account. Use this to find valid email addresses for the 'from' parameter in send_email, reply_to_email, and forward_email."
+    )]
+    async fn list_identities(&self) -> ToolResult {
+        let client = self.client.lock().await;
+        match client.list_identities().await {
+            Ok(identities) => {
+                if identities.is_empty() {
+                    return Self::text_result("No identities found.");
+                }
+                let text = identities
+                    .iter()
+                    .enumerate()
+                    .map(|(i, id)| {
+                        let display_name = if id.name.is_empty() {
+                            "(unnamed)"
+                        } else {
+                            &id.name
+                        };
+                        format!(
+                            "{}. {} <{}>\n   ID: {}",
+                            i + 1,
+                            display_name,
+                            id.email,
+                            id.id,
+                        )
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n\n");
+                Self::text_result(format!("Identities ({}):\n\n{}", identities.len(), text))
+            }
+            Err(e) => Self::error_result(format!("Failed to list identities: {}", e)),
         }
     }
 
@@ -519,8 +563,14 @@ impl FastmailMcp {
             .unwrap_or_default();
 
         if req.action == "preview" {
+            let from_line = req
+                .from
+                .as_deref()
+                .map(|f| format!("From: {}\n", f))
+                .unwrap_or_default();
             return Self::text_result(format!(
                 "EMAIL PREVIEW - Review before sending:\n\n\
+                {}\
                 To: {}\n\
                 CC: {}\n\
                 BCC: {}\n\
@@ -529,6 +579,7 @@ impl FastmailMcp {
                 {}\n\n\
                 ---\n\
                 To send this email, call this tool again with action: \"confirm\" and the same parameters.",
+                from_line,
                 format_address_list(Some(&to_addrs)),
                 if cc_addrs.is_empty() {
                     "(none)".to_string()
@@ -554,6 +605,7 @@ impl FastmailMcp {
                 &req.subject,
                 &req.body,
                 None,
+                req.from.as_deref(),
             )
             .await
         {
@@ -608,8 +660,14 @@ impl FastmailMcp {
         let to_addrs: Vec<EmailAddress> = original.from.clone().unwrap_or_default();
 
         if req.action == "preview" {
+            let from_line = req
+                .from
+                .as_deref()
+                .map(|f| format!("From: {}\n", f))
+                .unwrap_or_default();
             return Self::text_result(format!(
                 "REPLY PREVIEW - Review before sending:\n\n\
+                {}\
                 To: {}\n\
                 CC: {}\n\
                 BCC: {}\n\
@@ -619,6 +677,7 @@ impl FastmailMcp {
                 {}\n\n\
                 ---\n\
                 To send this reply, call this tool again with action: \"confirm\" and the same parameters.",
+                from_line,
                 format_address_list(Some(&to_addrs)),
                 if cc_addrs.is_empty() {
                     "(none)".to_string()
@@ -641,7 +700,7 @@ impl FastmailMcp {
         }
 
         match client
-            .reply_email(&original, &req.body, reply_all, cc_addrs, bcc_addrs)
+            .reply_email(&original, &req.body, reply_all, cc_addrs, bcc_addrs, req.from.as_deref())
             .await
         {
             Ok(email_id) => Self::text_result(format!(
@@ -703,8 +762,14 @@ impl FastmailMcp {
         let sender = format_address_list(original.from.as_ref());
 
         if req.action == "preview" {
+            let from_line = req
+                .from
+                .as_deref()
+                .map(|f| format!("From: {}\n", f))
+                .unwrap_or_default();
             return Self::text_result(format!(
                 "FORWARD PREVIEW - Review before sending:\n\n\
+                {}\
                 To: {}\n\
                 CC: {}\n\
                 BCC: {}\n\
@@ -719,6 +784,7 @@ impl FastmailMcp {
                 {}\n\n\
                 ---\n\
                 To send this forward, call this tool again with action: \"confirm\" and the same parameters.",
+                from_line,
                 format_address_list(Some(&to_addrs)),
                 if cc_addrs.is_empty() {
                     "(none)".to_string()
@@ -741,7 +807,7 @@ impl FastmailMcp {
         }
 
         match client
-            .forward_email(&original, to_addrs.clone(), body, cc_addrs, bcc_addrs)
+            .forward_email(&original, to_addrs.clone(), body, cc_addrs, bcc_addrs, req.from.as_deref())
             .await
         {
             Ok(email_id) => Self::text_result(format!(


### PR DESCRIPTION
## Summary

- Adds optional `--from <email>` parameter to `send`, `reply`, and `forward` commands (CLI and MCP)
- Adds `list identities` CLI command and `list_identities` MCP tool for discoverability
- Adds `IdentityNotFoundForEmail` error variant with actionable hint

All changes are backward-compatible: omitting `--from` uses the default (first) identity, same as before.

## Problem

Users with multiple Fastmail identities (aliases) cannot choose which address to send from. The CLI hardcodes `identities.first()` in all send operations, so replies always go from the primary address regardless of which alias received the original email.

## Changes

| File | Change |
|------|--------|
| `src/error.rs` | +1 error variant (`IdentityNotFoundForEmail`) |
| `src/jmap/mod.rs` | +`resolve_identity` helper, modified 3 method signatures |
| `src/commands/send.rs` | +`from` param passthrough |
| `src/commands/reply.rs` | +`from` param passthrough |
| `src/commands/forward.rs` | +`from` param passthrough |
| `src/commands/list.rs` | +`list_identities` command function |
| `src/main.rs` | +`--from` arg on Send/Reply/Forward, +`Identities` list subcommand |
| `src/mcp/mod.rs` | +`from` field on 3 request types, +`list_identities` MCP tool, updated previews |
| `README.md` | Usage examples for `--from` and `list identities` |

## Test plan

- [ ] `fastmail-cli list identities` returns all account identities
- [ ] `fastmail-cli send --from "alias@example.com" ...` sends from the specified identity
- [ ] `fastmail-cli send ...` (no --from) uses default identity (backward compat)
- [ ] `fastmail-cli send --from "nonexistent@example.com" ...` shows clear error with hint
- [ ] MCP: `send_email`, `reply_to_email`, `forward_email` accept optional `from` parameter
- [ ] MCP: `list_identities` tool returns formatted identity list
- [ ] MCP: preview format shows "From:" line when `from` is specified

🤖 Generated with [Claude Code](https://claude.com/claude-code)