### PR TITLE
refactor: code quality audit cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,8 +82,7 @@ app_password = "..."
 - Full JMAP filter support for search command
 - Search flags: `--text`, `--from`, `--to`, `--cc`, `--bcc`, `--subject`, `--body`
 - Search flags: `--mailbox`, `--has-attachment`, `--min-size`, `--max-size`
-- Search flags: `--before`, `--after`, `--unread`, `--flagged`, `--pinned`
-- `--pinned` shortcut for `--flagged --mailbox INBOX`
+- Search flags: `--before`, `--after`, `--unread`, `--flagged`
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,33 +3,49 @@ name = "fastmail-cli"
 version = "1.7.1"
 edition = "2024"
 description = "CLI for Fastmail's JMAP API"
-license = "MIT"
 repository = "https://github.com/radiosilence/fastmail-cli"
-keywords = ["fastmail", "jmap", "email", "cli"]
+license = "MIT"
+keywords = ["cli", "email", "fastmail", "jmap"]
 categories = ["command-line-utilities", "email"]
 
 [dependencies]
 anyhow = "1.0.100"
 base64 = "0.22"
-chrono = { version = "0.4.42", features = ["serde"] }
 clap = { version = "4.5.54", features = ["derive"] }
 clap_complete = "4.5.65"
 dirs = "6.0.0"
-image = { version = "0.25", default-features = false, features = ["jpeg", "png", "gif", "webp"] }
-kreuzberg = { version = "4.0", features = ["pdf", "bundled-pdfium", "office", "email", "archives", "html", "xml", "excel", "language-detection"] }
-vcard = "0.4"
-reqwest = { version = "0.13.1", default-features = false, features = ["json", "rustls"] }
+image = { version = "0.25", default-features = false, features = [
+  "gif",
+  "jpeg",
+  "png",
+  "webp"
+] }
+kreuzberg = { version = "4.0", features = [
+  "archives",
+  "bundled-pdfium",
+  "email",
+  "excel",
+  "html",
+  "language-detection",
+  "office",
+  "pdf",
+  "xml"
+] }
+reqwest = { version = "0.13.1", default-features = false, features = [
+  "json",
+  "rustls"
+] }
 rmcp = { version = "0.12", features = ["server", "transport-io"] }
 schemars = "0.8"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
-toml = "0.8"
 thiserror = "2.0.17"
 tokio = { version = "1.49.0", features = ["full"] }
+toml = "0.8"
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
 
 [profile.release]
-lto = true
 strip = true
+lto = true
 codegen-units = 1

--- a/README.md
+++ b/README.md
@@ -122,9 +122,6 @@ fastmail-cli search --after 2024-01-01 --before 2024-12-31
 fastmail-cli search --unread
 fastmail-cli search --flagged
 
-# Pinned emails (shortcut for --flagged --mailbox INBOX)
-fastmail-cli search --pinned
-
 # Combine filters
 fastmail-cli search --from "boss" --has-attachment --after 2024-06-01 --limit 20
 ```

--- a/src/commands/download.rs
+++ b/src/commands/download.rs
@@ -1,5 +1,4 @@
-use crate::config::Config;
-use crate::jmap::JmapClient;
+use crate::jmap::authenticated_client;
 use crate::models::Output;
 use crate::util::{extract_text, infer_image_mime, is_image, parse_size, resize_image};
 use std::path::Path;
@@ -11,11 +10,7 @@ pub async fn download_attachment(
     max_size: Option<&str>,
 ) -> anyhow::Result<()> {
     let max_bytes = max_size.and_then(parse_size);
-    let config = Config::load()?;
-    let token = config.get_token()?;
-
-    let mut client = JmapClient::new(token.to_string());
-    client.authenticate().await?;
+    let client = authenticated_client().await?;
 
     let email = client.get_email(email_id).await?;
 

--- a/src/commands/forward.rs
+++ b/src/commands/forward.rs
@@ -1,5 +1,4 @@
-use crate::config::Config;
-use crate::jmap::JmapClient;
+use crate::jmap::authenticated_client;
 use crate::models::Output;
 use crate::util::parse_addresses;
 
@@ -10,11 +9,7 @@ pub async fn forward(
     cc: Option<&str>,
     bcc: Option<&str>,
 ) -> anyhow::Result<()> {
-    let config = Config::load()?;
-    let token = config.get_token()?;
-
-    let mut client = JmapClient::new(token.to_string());
-    client.authenticate().await?;
+    let client = authenticated_client().await?;
 
     let original = client.get_email(email_id).await?;
 

--- a/src/commands/get.rs
+++ b/src/commands/get.rs
@@ -1,13 +1,8 @@
-use crate::config::Config;
-use crate::jmap::JmapClient;
+use crate::jmap::authenticated_client;
 use crate::models::Output;
 
 pub async fn get_email(email_id: &str) -> anyhow::Result<()> {
-    let config = Config::load()?;
-    let token = config.get_token()?;
-
-    let mut client = JmapClient::new(token.to_string());
-    client.authenticate().await?;
+    let client = authenticated_client().await?;
 
     let email = client.get_email(email_id).await?;
     Output::success(email).print();

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -1,13 +1,8 @@
-use crate::config::Config;
-use crate::jmap::JmapClient;
+use crate::jmap::authenticated_client;
 use crate::models::{Email, Mailbox, Output};
 
 pub async fn list_mailboxes() -> anyhow::Result<()> {
-    let config = Config::load()?;
-    let token = config.get_token()?;
-
-    let mut client = JmapClient::new(token.to_string());
-    client.authenticate().await?;
+    let client = authenticated_client().await?;
 
     let mailboxes = client.list_mailboxes().await?;
     Output::success(mailboxes).print();
@@ -16,11 +11,7 @@ pub async fn list_mailboxes() -> anyhow::Result<()> {
 }
 
 pub async fn list_emails(mailbox: &str, limit: u32) -> anyhow::Result<()> {
-    let config = Config::load()?;
-    let token = config.get_token()?;
-
-    let mut client = JmapClient::new(token.to_string());
-    client.authenticate().await?;
+    let client = authenticated_client().await?;
 
     let mailbox = client.find_mailbox(mailbox).await?;
     let emails = client.list_emails(&mailbox.id, limit).await?;

--- a/src/commands/masked.rs
+++ b/src/commands/masked.rs
@@ -1,13 +1,8 @@
-use crate::config::Config;
-use crate::jmap::JmapClient;
+use crate::jmap::authenticated_client;
 use crate::models::Output;
 
 pub async fn list_masked_emails() -> anyhow::Result<()> {
-    let config = Config::load()?;
-    let token = config.get_token()?;
-
-    let mut client = JmapClient::new(token.to_string());
-    client.authenticate().await?;
+    let client = authenticated_client().await?;
 
     let masked_emails = client.list_masked_emails().await?;
 
@@ -20,11 +15,7 @@ pub async fn create_masked_email(
     description: Option<&str>,
     prefix: Option<&str>,
 ) -> anyhow::Result<()> {
-    let config = Config::load()?;
-    let token = config.get_token()?;
-
-    let mut client = JmapClient::new(token.to_string());
-    client.authenticate().await?;
+    let client = authenticated_client().await?;
 
     let masked_email = client
         .create_masked_email(for_domain, description, prefix)
@@ -35,11 +26,7 @@ pub async fn create_masked_email(
 }
 
 pub async fn enable_masked_email(id: &str) -> anyhow::Result<()> {
-    let config = Config::load()?;
-    let token = config.get_token()?;
-
-    let mut client = JmapClient::new(token.to_string());
-    client.authenticate().await?;
+    let client = authenticated_client().await?;
 
     client
         .update_masked_email(id, Some("enabled"), None, None)
@@ -50,11 +37,7 @@ pub async fn enable_masked_email(id: &str) -> anyhow::Result<()> {
 }
 
 pub async fn disable_masked_email(id: &str) -> anyhow::Result<()> {
-    let config = Config::load()?;
-    let token = config.get_token()?;
-
-    let mut client = JmapClient::new(token.to_string());
-    client.authenticate().await?;
+    let client = authenticated_client().await?;
 
     client
         .update_masked_email(id, Some("disabled"), None, None)
@@ -65,11 +48,7 @@ pub async fn disable_masked_email(id: &str) -> anyhow::Result<()> {
 }
 
 pub async fn delete_masked_email(id: &str) -> anyhow::Result<()> {
-    let config = Config::load()?;
-    let token = config.get_token()?;
-
-    let mut client = JmapClient::new(token.to_string());
-    client.authenticate().await?;
+    let client = authenticated_client().await?;
 
     client
         .update_masked_email(id, Some("deleted"), None, None)

--- a/src/commands/move.rs
+++ b/src/commands/move.rs
@@ -1,13 +1,8 @@
-use crate::config::Config;
-use crate::jmap::JmapClient;
+use crate::jmap::authenticated_client;
 use crate::models::Output;
 
 pub async fn move_email(email_id: &str, mailbox: &str) -> anyhow::Result<()> {
-    let config = Config::load()?;
-    let token = config.get_token()?;
-
-    let mut client = JmapClient::new(token.to_string());
-    client.authenticate().await?;
+    let client = authenticated_client().await?;
 
     let mailbox = client.find_mailbox(mailbox).await?;
     client.move_email(email_id, &mailbox.id).await?;

--- a/src/commands/read.rs
+++ b/src/commands/read.rs
@@ -1,13 +1,8 @@
-use crate::config::Config;
-use crate::jmap::JmapClient;
+use crate::jmap::authenticated_client;
 use crate::models::Output;
 
 pub async fn mark_read(email_id: &str, read: bool) -> anyhow::Result<()> {
-    let config = Config::load()?;
-    let token = config.get_token()?;
-
-    let mut client = JmapClient::new(token.to_string());
-    client.authenticate().await?;
+    let client = authenticated_client().await?;
 
     let email = client.get_email(email_id).await?;
 

--- a/src/commands/reply.rs
+++ b/src/commands/reply.rs
@@ -1,5 +1,4 @@
-use crate::config::Config;
-use crate::jmap::JmapClient;
+use crate::jmap::authenticated_client;
 use crate::models::Output;
 use crate::util::parse_addresses;
 
@@ -10,11 +9,7 @@ pub async fn reply(
     cc: Option<&str>,
     bcc: Option<&str>,
 ) -> anyhow::Result<()> {
-    let config = Config::load()?;
-    let token = config.get_token()?;
-
-    let mut client = JmapClient::new(token.to_string());
-    client.authenticate().await?;
+    let client = authenticated_client().await?;
 
     let original = client.get_email(email_id).await?;
 

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -1,5 +1,4 @@
-use crate::config::Config;
-use crate::jmap::JmapClient;
+use crate::jmap::authenticated_client;
 use crate::models::Output;
 
 /// Search filter matching JMAP Email/query FilterCondition
@@ -23,11 +22,7 @@ pub struct SearchFilter {
 }
 
 pub async fn search(filter: SearchFilter, limit: u32) -> anyhow::Result<()> {
-    let config = Config::load()?;
-    let token = config.get_token()?;
-
-    let mut client = JmapClient::new(token.to_string());
-    client.authenticate().await?;
+    let client = authenticated_client().await?;
 
     // Resolve mailbox name to ID if specified
     let mailbox_id = if let Some(ref mailbox_name) = filter.mailbox {

--- a/src/commands/send.rs
+++ b/src/commands/send.rs
@@ -1,34 +1,6 @@
-use crate::config::Config;
-use crate::jmap::JmapClient;
-use crate::models::{EmailAddress, Output};
-
-fn parse_addresses(input: &str) -> Vec<EmailAddress> {
-    input
-        .split(',')
-        .map(|s| s.trim())
-        .filter(|s| !s.is_empty())
-        .map(|s| {
-            if let Some(start) = s.find('<')
-                && let Some(end) = s.find('>')
-            {
-                let name = s[..start].trim();
-                let email = s[start + 1..end].trim();
-                return EmailAddress {
-                    name: if name.is_empty() {
-                        None
-                    } else {
-                        Some(name.to_string())
-                    },
-                    email: email.to_string(),
-                };
-            }
-            EmailAddress {
-                name: None,
-                email: s.to_string(),
-            }
-        })
-        .collect()
-}
+use crate::jmap::authenticated_client;
+use crate::models::Output;
+use crate::util::parse_addresses;
 
 pub async fn send(
     to: &str,
@@ -38,11 +10,7 @@ pub async fn send(
     bcc: Option<&str>,
     reply_to: Option<&str>,
 ) -> anyhow::Result<()> {
-    let config = Config::load()?;
-    let token = config.get_token()?;
-
-    let mut client = JmapClient::new(token.to_string());
-    client.authenticate().await?;
+    let client = authenticated_client().await?;
 
     let to_addrs = parse_addresses(to);
     let cc_addrs = cc.map(parse_addresses).unwrap_or_default();

--- a/src/commands/spam.rs
+++ b/src/commands/spam.rs
@@ -1,13 +1,8 @@
-use crate::config::Config;
-use crate::jmap::JmapClient;
+use crate::jmap::authenticated_client;
 use crate::models::Output;
 
 pub async fn mark_spam(email_id: &str) -> anyhow::Result<()> {
-    let config = Config::load()?;
-    let token = config.get_token()?;
-
-    let mut client = JmapClient::new(token.to_string());
-    client.authenticate().await?;
+    let client = authenticated_client().await?;
 
     client.mark_spam(email_id).await?;
 

--- a/src/commands/thread.rs
+++ b/src/commands/thread.rs
@@ -1,13 +1,8 @@
-use crate::config::Config;
-use crate::jmap::JmapClient;
+use crate::jmap::authenticated_client;
 use crate::models::Output;
 
 pub async fn get_thread(email_id: &str) -> anyhow::Result<()> {
-    let config = Config::load()?;
-    let token = config.get_token()?;
-
-    let mut client = JmapClient::new(token.to_string());
-    client.authenticate().await?;
+    let client = authenticated_client().await?;
 
     let emails = client.get_thread(email_id).await?;
     Output::success(emails).print();

--- a/src/config.rs
+++ b/src/config.rs
@@ -119,13 +119,27 @@ mod tests {
 
     #[test]
     fn test_config_get_token_none() {
+        // Temporarily remove env var so we test config-only path
+        let saved = std::env::var("FASTMAIL_API_TOKEN").ok();
+        // SAFETY: test-only, single-threaded test runner for these tests
+        unsafe { std::env::remove_var("FASTMAIL_API_TOKEN") };
+
         let config = Config::default();
         let result = config.get_token();
         assert!(matches!(result, Err(Error::NotAuthenticated)));
+
+        if let Some(val) = saved {
+            unsafe { std::env::set_var("FASTMAIL_API_TOKEN", val) };
+        }
     }
 
     #[test]
     fn test_config_get_token_some() {
+        // Temporarily remove env var so we test config-only path
+        let saved = std::env::var("FASTMAIL_API_TOKEN").ok();
+        // SAFETY: test-only, single-threaded test runner for these tests
+        unsafe { std::env::remove_var("FASTMAIL_API_TOKEN") };
+
         let config = Config {
             core: CoreConfig {
                 api_token: Some("test-token".to_string()),
@@ -133,6 +147,10 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(config.get_token().unwrap(), "test-token");
+
+        if let Some(val) = saved {
+            unsafe { std::env::set_var("FASTMAIL_API_TOKEN", val) };
+        }
     }
 
     #[test]

--- a/src/jmap/mod.rs
+++ b/src/jmap/mod.rs
@@ -24,6 +24,48 @@ pub struct JmapClient {
     session: Option<Session>,
 }
 
+/// Create an authenticated JMAP client from config
+pub async fn authenticated_client() -> crate::error::Result<JmapClient> {
+    let config = crate::config::Config::load()?;
+    let token = config.get_token()?;
+    let mut client = JmapClient::new(token);
+    client.authenticate().await?;
+    Ok(client)
+}
+
+// Shared JMAP response types used across multiple methods
+#[derive(Deserialize)]
+struct GetResponse<T> {
+    list: Vec<T>,
+}
+
+#[derive(Deserialize)]
+struct GetResponseWithNotFound<T> {
+    list: Vec<T>,
+    #[serde(rename = "notFound")]
+    not_found: Vec<String>,
+}
+
+#[derive(Deserialize)]
+struct EmailSetResponse {
+    created: Option<HashMap<String, Value>>,
+    #[serde(rename = "notCreated")]
+    not_created: Option<HashMap<String, Value>>,
+}
+
+#[derive(Deserialize)]
+struct SetResponse {
+    #[serde(rename = "notUpdated")]
+    not_updated: Option<HashMap<String, Value>>,
+}
+
+#[derive(Deserialize)]
+struct MaskedEmailCreateResponse {
+    created: Option<HashMap<String, MaskedEmail>>,
+    #[serde(rename = "notCreated")]
+    not_created: Option<HashMap<String, Value>>,
+}
+
 #[derive(Debug, Serialize)]
 struct JmapRequest {
     using: Vec<String>,
@@ -170,12 +212,7 @@ impl JmapClient {
             ])])
             .await?;
 
-        #[derive(Deserialize)]
-        struct MailboxGetResponse {
-            list: Vec<Mailbox>,
-        }
-
-        let resp: MailboxGetResponse =
+        let resp: GetResponse<Mailbox> =
             Self::parse_response(responses.first().unwrap_or(&Value::Null), "Mailbox/get")?;
 
         Ok(resp.list)
@@ -241,12 +278,7 @@ impl JmapClient {
             ])
             .await?;
 
-        #[derive(Deserialize)]
-        struct EmailGetResponse {
-            list: Vec<Email>,
-        }
-
-        let resp: EmailGetResponse =
+        let resp: GetResponse<Email> =
             Self::parse_response(responses.get(1).unwrap_or(&Value::Null), "Email/get")?;
 
         Ok(resp.list)
@@ -279,14 +311,7 @@ impl JmapClient {
             ])])
             .await?;
 
-        #[derive(Deserialize)]
-        struct EmailGetResponse {
-            list: Vec<Email>,
-            #[serde(rename = "notFound")]
-            not_found: Vec<String>,
-        }
-
-        let resp: EmailGetResponse =
+        let resp: GetResponseWithNotFound<Email> =
             Self::parse_response(responses.first().unwrap_or(&Value::Null), "Email/get")?;
 
         if !resp.not_found.is_empty() {
@@ -331,12 +356,7 @@ impl JmapClient {
             email_ids: Vec<String>,
         }
 
-        #[derive(Deserialize)]
-        struct ThreadGetResponse {
-            list: Vec<Thread>,
-        }
-
-        let thread_resp: ThreadGetResponse =
+        let thread_resp: GetResponse<Thread> =
             Self::parse_response(responses.first().unwrap_or(&Value::Null), "Thread/get")?;
 
         let thread = thread_resp
@@ -364,12 +384,7 @@ impl JmapClient {
             ])])
             .await?;
 
-        #[derive(Deserialize)]
-        struct EmailGetResponse {
-            list: Vec<Email>,
-        }
-
-        let resp: EmailGetResponse =
+        let resp: GetResponse<Email> =
             Self::parse_response(responses.first().unwrap_or(&Value::Null), "Email/get")?;
 
         Ok(resp.list)
@@ -480,12 +495,7 @@ impl JmapClient {
             ])
             .await?;
 
-        #[derive(Deserialize)]
-        struct EmailGetResponse {
-            list: Vec<Email>,
-        }
-
-        let resp: EmailGetResponse =
+        let resp: GetResponse<Email> =
             Self::parse_response(responses.get(1).unwrap_or(&Value::Null), "Email/get")?;
 
         Ok(resp.list)
@@ -506,12 +516,7 @@ impl JmapClient {
             ])])
             .await?;
 
-        #[derive(Deserialize)]
-        struct IdentityGetResponse {
-            list: Vec<Identity>,
-        }
-
-        let resp: IdentityGetResponse =
+        let resp: GetResponse<Identity> =
             Self::parse_response(responses.first().unwrap_or(&Value::Null), "Identity/get")?;
 
         Ok(resp.list)
@@ -616,13 +621,6 @@ impl JmapClient {
             ])
             .await?;
 
-        #[derive(Deserialize)]
-        struct EmailSetResponse {
-            created: Option<HashMap<String, Value>>,
-            #[serde(rename = "notCreated")]
-            not_created: Option<HashMap<String, Value>>,
-        }
-
         let email_resp: EmailSetResponse =
             Self::parse_response(responses.first().unwrap_or(&Value::Null), "Email/set")?;
 
@@ -683,12 +681,6 @@ impl JmapClient {
                 "m0"
             ])])
             .await?;
-
-        #[derive(Deserialize)]
-        struct SetResponse {
-            #[serde(rename = "notUpdated")]
-            not_updated: Option<HashMap<String, Value>>,
-        }
 
         let resp: SetResponse =
             Self::parse_response(responses.first().unwrap_or(&Value::Null), "Email/set")?;
@@ -911,13 +903,6 @@ impl JmapClient {
             ])
             .await?;
 
-        #[derive(Deserialize)]
-        struct EmailSetResponse {
-            created: Option<HashMap<String, Value>>,
-            #[serde(rename = "notCreated")]
-            not_created: Option<HashMap<String, Value>>,
-        }
-
         let email_resp: EmailSetResponse =
             Self::parse_response(responses.first().unwrap_or(&Value::Null), "Email/set")?;
 
@@ -1096,13 +1081,6 @@ impl JmapClient {
             ])
             .await?;
 
-        #[derive(Deserialize)]
-        struct EmailSetResponse {
-            created: Option<HashMap<String, Value>>,
-            #[serde(rename = "notCreated")]
-            not_created: Option<HashMap<String, Value>>,
-        }
-
         let email_resp: EmailSetResponse =
             Self::parse_response(responses.first().unwrap_or(&Value::Null), "Email/set")?;
 
@@ -1142,7 +1120,6 @@ impl JmapClient {
         Ok(email_id)
     }
 
-    #[allow(dead_code)]
     #[instrument(skip(self))]
     pub async fn set_keywords(
         &self,
@@ -1168,12 +1145,6 @@ impl JmapClient {
                 "k0"
             ])])
             .await?;
-
-        #[derive(Deserialize)]
-        struct SetResponse {
-            #[serde(rename = "notUpdated")]
-            not_updated: Option<HashMap<String, Value>>,
-        }
 
         let resp: SetResponse =
             Self::parse_response(responses.first().unwrap_or(&Value::Null), "Email/set")?;
@@ -1218,12 +1189,7 @@ impl JmapClient {
             ])])
             .await?;
 
-        #[derive(Deserialize)]
-        struct MaskedEmailGetResponse {
-            list: Vec<MaskedEmail>,
-        }
-
-        let resp: MaskedEmailGetResponse =
+        let resp: GetResponse<MaskedEmail> =
             Self::parse_response(responses.first().unwrap_or(&Value::Null), "MaskedEmail/get")?;
 
         Ok(resp.list)
@@ -1266,14 +1232,7 @@ impl JmapClient {
             ])])
             .await?;
 
-        #[derive(Deserialize)]
-        struct MaskedEmailSetResponse {
-            created: Option<HashMap<String, MaskedEmail>>,
-            #[serde(rename = "notCreated")]
-            not_created: Option<HashMap<String, Value>>,
-        }
-
-        let resp: MaskedEmailSetResponse =
+        let resp: MaskedEmailCreateResponse =
             Self::parse_response(responses.first().unwrap_or(&Value::Null), "MaskedEmail/set")?;
 
         if let Some(ref not_created) = resp.not_created
@@ -1338,12 +1297,6 @@ impl JmapClient {
                 "me0"
             ])])
             .await?;
-
-        #[derive(Deserialize)]
-        struct SetResponse {
-            #[serde(rename = "notUpdated")]
-            not_updated: Option<HashMap<String, Value>>,
-        }
 
         let resp: SetResponse =
             Self::parse_response(responses.first().unwrap_or(&Value::Null), "MaskedEmail/set")?;

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -16,7 +16,9 @@ use crate::carddav::CardDavClient;
 use crate::config::Config;
 use crate::jmap::JmapClient;
 use crate::models::EmailAddress;
-use crate::util::{MCP_IMAGE_MAX_BYTES, extract_text, infer_image_mime, is_image, resize_image};
+use crate::util::{
+    MCP_IMAGE_MAX_BYTES, extract_text, infer_image_mime, is_image, parse_addresses, resize_image,
+};
 
 type ToolResult = std::result::Result<CallToolResult, McpError>;
 
@@ -231,15 +233,6 @@ impl FastmailMcp {
 
     fn error_result(msg: impl Into<String>) -> ToolResult {
         Ok(CallToolResult::error(vec![Content::text(msg.into())]))
-    }
-
-    fn parse_addresses(s: &str) -> Vec<EmailAddress> {
-        s.split(',')
-            .map(|e| EmailAddress {
-                name: None,
-                email: e.trim().to_string(),
-            })
-            .collect()
     }
 }
 
@@ -506,16 +499,16 @@ impl FastmailMcp {
         description = "Compose and send a new email. CRITICAL: You MUST call with action='preview' first, show the user the draft, get explicit approval, then call again with action='confirm'. NEVER skip the preview step."
     )]
     async fn send_email(&self, Parameters(req): Parameters<SendEmailRequest>) -> ToolResult {
-        let to_addrs = Self::parse_addresses(&req.to);
+        let to_addrs = parse_addresses(&req.to);
         let cc_addrs = req
             .cc
             .as_ref()
-            .map(|s| Self::parse_addresses(s))
+            .map(|s| parse_addresses(s))
             .unwrap_or_default();
         let bcc_addrs = req
             .bcc
             .as_ref()
-            .map(|s| Self::parse_addresses(s))
+            .map(|s| parse_addresses(s))
             .unwrap_or_default();
 
         if req.action == "preview" {
@@ -585,12 +578,12 @@ impl FastmailMcp {
         let cc_addrs = req
             .cc
             .as_ref()
-            .map(|s| Self::parse_addresses(s))
+            .map(|s| parse_addresses(s))
             .unwrap_or_default();
         let bcc_addrs = req
             .bcc
             .as_ref()
-            .map(|s| Self::parse_addresses(s))
+            .map(|s| parse_addresses(s))
             .unwrap_or_default();
 
         // Build subject
@@ -668,16 +661,16 @@ impl FastmailMcp {
             Err(e) => return Self::error_result(format!("Email not found: {}", e)),
         };
 
-        let to_addrs = Self::parse_addresses(&req.to);
+        let to_addrs = parse_addresses(&req.to);
         let cc_addrs = req
             .cc
             .as_ref()
-            .map(|s| Self::parse_addresses(s))
+            .map(|s| parse_addresses(s))
             .unwrap_or_default();
         let bcc_addrs = req
             .bcc
             .as_ref()
-            .map(|s| Self::parse_addresses(s))
+            .map(|s| parse_addresses(s))
             .unwrap_or_default();
         let body = req.body.as_deref().unwrap_or("");
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -62,35 +62,6 @@ pub async fn extract_text(bytes: &[u8], filename: &str) -> anyhow::Result<Option
     }
 }
 
-/// Synchronous version for non-async contexts
-/// NOTE: Returns None for images - use existing image pipeline instead
-pub fn extract_text_sync(bytes: &[u8], filename: &str) -> anyhow::Result<Option<String>> {
-    use kreuzberg::{ExtractionConfig, extract_bytes_sync};
-
-    // Skip images - we have our own pipeline for those (resize + send to Claude)
-    if is_image_extension(filename) {
-        return Ok(None);
-    }
-
-    let mime_type = mime_from_filename(filename);
-    let config = ExtractionConfig::default();
-
-    match extract_bytes_sync(bytes, &mime_type, &config) {
-        Ok(result) => {
-            let content = result.content.trim();
-            if content.is_empty() {
-                Ok(None)
-            } else {
-                Ok(Some(content.to_string()))
-            }
-        }
-        Err(e) => {
-            tracing::debug!("kreuzberg extraction failed for {}: {}", filename, e);
-            Ok(None)
-        }
-    }
-}
-
 /// Check if filename has an image extension (used to skip kreuzberg for images)
 fn is_image_extension(filename: &str) -> bool {
     let ext = Path::new(filename)
@@ -212,7 +183,7 @@ pub fn is_image(content_type: &str, filename: &str) -> bool {
         .to_lowercase();
     matches!(
         ext.as_str(),
-        "png" | "jpg" | "jpeg" | "gif" | "webp" | "bmp" | "tiff"
+        "png" | "jpg" | "jpeg" | "gif" | "webp" | "bmp" | "tiff" | "tif" | "ico" | "heic"
     )
 }
 


### PR DESCRIPTION
## Code Quality Audit

Full audit of the codebase covering duplication, dead code, bugs, inconsistencies, and test reliability. Net -160 lines.

### Duplication Fixes
- parse_addresses duplicated 3x - send.rs had its own copy, MCP had an inferior version that silently dropped Name <email> format (actual bug for MCP users sending to named recipients). Both now use util::parse_addresses.
- 13 inline response structs in jmap/mod.rs - EmailGetResponse defined 4x, EmailSetResponse 3x, SetResponse 3x, plus others. Extracted into 5 shared generic types.
- 4-line client init boilerplate in every command - Extracted authenticated_client() helper, cleaning up all 11 command modules.

### Dead Code / Unused Dependencies
- Removed vcard crate (in Cargo.toml but never imported - manual vCard parsing used)
- Removed chrono crate (in Cargo.toml but never imported anywhere in src/)
- Removed extract_text_sync function (defined but never called)
- Removed incorrect allow(dead_code) on set_keywords (it is used by both MCP and CLI)

### Bug Fixes
- is_image() missing extensions - is_image_extension() handled tif/heic/ico but is_image() did not, causing inconsistent behavior for those image types in attachment handling
- Config tests failing when FASTMAIL_API_TOKEN set - Pre-existing bug where tests would fail in any environment with the env var set. Tests now properly isolate the env.
- --pinned flag documented but never implemented - Removed from README and CHANGELOG

### Verification
- cargo fmt - clean
- cargo clippy -- -D warnings - zero warnings
- cargo test - 24/24 passing