### PR TITLE
feat: add --draft flag to send/reply/forward

### DIFF
--- a/src/commands/forward.rs
+++ b/src/commands/forward.rs
@@ -1,4 +1,4 @@
-use crate::jmap::authenticated_client;
+use crate::jmap::{ComposeParams, authenticated_client};
 use crate::models::Output;
 use crate::util::parse_addresses;
 
@@ -6,31 +6,28 @@ pub async fn forward(
     email_id: &str,
     to: &str,
     body: &str,
-    cc: Option<&str>,
-    bcc: Option<&str>,
-    from: Option<&str>,
+    params: ComposeParams<'_>,
 ) -> anyhow::Result<()> {
     let client = authenticated_client().await?;
+    let draft = params.draft;
 
     let original = client.get_email(email_id).await?;
 
-    let to_addrs = parse_addresses(to);
-    let cc_addrs = cc.map(parse_addresses).unwrap_or_default();
-    let bcc_addrs = bcc.map(parse_addresses).unwrap_or_default();
-
     let new_email_id = client
-        .forward_email(&original, to_addrs, body, cc_addrs, bcc_addrs, from)
+        .forward_email(&original, parse_addresses(to), body, params)
         .await?;
 
     #[derive(serde::Serialize)]
     struct ForwardResponse {
         email_id: String,
         forwarded_from: String,
+        status: &'static str,
     }
 
     Output::success(ForwardResponse {
         email_id: new_email_id,
         forwarded_from: email_id.to_string(),
+        status: if draft { "draft" } else { "sent" },
     })
     .print();
 

--- a/src/commands/reply.rs
+++ b/src/commands/reply.rs
@@ -1,35 +1,32 @@
-use crate::jmap::authenticated_client;
+use crate::jmap::{ComposeParams, authenticated_client};
 use crate::models::Output;
-use crate::util::parse_addresses;
 
 pub async fn reply(
     email_id: &str,
     body: &str,
     reply_all: bool,
-    cc: Option<&str>,
-    bcc: Option<&str>,
-    from: Option<&str>,
+    params: ComposeParams<'_>,
 ) -> anyhow::Result<()> {
     let client = authenticated_client().await?;
+    let draft = params.draft;
 
     let original = client.get_email(email_id).await?;
 
-    let cc_addrs = cc.map(parse_addresses).unwrap_or_default();
-    let bcc_addrs = bcc.map(parse_addresses).unwrap_or_default();
-
     let new_email_id = client
-        .reply_email(&original, body, reply_all, cc_addrs, bcc_addrs, from)
+        .reply_email(&original, body, reply_all, params)
         .await?;
 
     #[derive(serde::Serialize)]
     struct ReplyResponse {
         email_id: String,
         in_reply_to: String,
+        status: &'static str,
     }
 
     Output::success(ReplyResponse {
         email_id: new_email_id,
         in_reply_to: email_id.to_string(),
+        status: if draft { "draft" } else { "sent" },
     })
     .print();
 

--- a/src/commands/send.rs
+++ b/src/commands/send.rs
@@ -1,4 +1,4 @@
-use crate::jmap::authenticated_client;
+use crate::jmap::{ComposeParams, authenticated_client};
 use crate::models::Output;
 use crate::util::parse_addresses;
 
@@ -6,27 +6,27 @@ pub async fn send(
     to: &str,
     subject: &str,
     body: &str,
-    cc: Option<&str>,
-    bcc: Option<&str>,
     reply_to: Option<&str>,
-    from: Option<&str>,
+    params: ComposeParams<'_>,
 ) -> anyhow::Result<()> {
     let client = authenticated_client().await?;
-
-    let to_addrs = parse_addresses(to);
-    let cc_addrs = cc.map(parse_addresses).unwrap_or_default();
-    let bcc_addrs = bcc.map(parse_addresses).unwrap_or_default();
+    let draft = params.draft;
 
     let email_id = client
-        .send_email(to_addrs, cc_addrs, bcc_addrs, subject, body, reply_to, from)
+        .send_email(parse_addresses(to), subject, body, reply_to, params)
         .await?;
 
     #[derive(serde::Serialize)]
     struct SendResponse {
         email_id: String,
+        status: &'static str,
     }
 
-    Output::success(SendResponse { email_id }).print();
+    Output::success(SendResponse {
+        email_id,
+        status: if draft { "draft" } else { "sent" },
+    })
+    .print();
 
     Ok(())
 }

--- a/src/jmap/mod.rs
+++ b/src/jmap/mod.rs
@@ -34,6 +34,74 @@ pub async fn authenticated_client() -> crate::error::Result<JmapClient> {
     Ok(client)
 }
 
+/// Common parameters for compose operations (send, reply, forward)
+pub struct ComposeParams<'a> {
+    pub cc: Vec<EmailAddress>,
+    pub bcc: Vec<EmailAddress>,
+    pub from: Option<&'a str>,
+    pub draft: bool,
+}
+
+/// Resolved context for a compose operation
+struct ComposeContext {
+    account_id: String,
+    mailbox: Mailbox,
+    identity: Option<Identity>,
+    draft: bool,
+}
+
+impl ComposeContext {
+    fn apply_to_email(&self, email_create: &mut HashMap<String, Value>) {
+        email_create.insert(
+            "mailboxIds".into(),
+            json!({ self.mailbox.id.clone(): true }),
+        );
+        if self.draft {
+            email_create.insert("keywords".into(), json!({ "$draft": true, "$seen": true }));
+        }
+        if let Some(ref identity) = self.identity {
+            email_create.insert(
+                "from".into(),
+                json!([{ "email": identity.email, "name": identity.name }]),
+            );
+        }
+    }
+
+    fn build_method_calls(&self, email_create: HashMap<String, Value>) -> Vec<Value> {
+        let mut calls = vec![json!([
+            "Email/set",
+            {
+                "accountId": self.account_id,
+                "create": { "email": email_create }
+            },
+            "e0"
+        ])];
+        if !self.draft
+            && let Some(ref identity) = self.identity
+        {
+            calls.push(json!([
+                "EmailSubmission/set",
+                {
+                    "accountId": self.account_id,
+                    "create": {
+                        "submission": {
+                            "identityId": identity.id,
+                            "emailId": "#email"
+                        }
+                    },
+                    "onSuccessUpdateEmail": {
+                        "#submission": {
+                            "keywords/$seen": true
+                        }
+                    }
+                },
+                "s0"
+            ]));
+        }
+        calls
+    }
+}
+
 // Shared JMAP response types used across multiple methods
 #[derive(Deserialize)]
 struct GetResponse<T> {
@@ -561,108 +629,34 @@ impl JmapClient {
         pick_identity(identities, from)
     }
 
-    #[allow(clippy::too_many_arguments)]
-    #[instrument(skip(self, body))]
-    pub async fn send_email(
-        &self,
-        to: Vec<EmailAddress>,
-        cc: Vec<EmailAddress>,
-        bcc: Vec<EmailAddress>,
-        subject: &str,
-        body: &str,
-        in_reply_to: Option<&str>,
-        from: Option<&str>,
-    ) -> Result<String> {
-        self.require_capability("urn:ietf:params:jmap:submission", "Email sending")?;
-
+    async fn prepare_compose(&self, from: Option<&str>, draft: bool) -> Result<ComposeContext> {
+        if !draft {
+            self.require_capability("urn:ietf:params:jmap:submission", "Email sending")?;
+        }
         let account_id = self
             .session()?
             .primary_account_id()
-            .ok_or_else(|| Error::Config("No primary account".into()))?;
+            .ok_or_else(|| Error::Config("No primary account".into()))?
+            .to_string();
+        let mailbox = if draft {
+            self.find_mailbox("drafts").await?
+        } else {
+            self.find_mailbox("sent").await?
+        };
+        let identity = match self.resolve_identity(from).await {
+            Ok(id) => Some(id),
+            Err(_) if draft => None,
+            Err(e) => return Err(e),
+        };
+        Ok(ComposeContext {
+            account_id,
+            mailbox,
+            identity,
+            draft,
+        })
+    }
 
-        let identity = self.resolve_identity(from).await?;
-
-        let sent = self.find_mailbox("sent").await?;
-
-        let mut email_create: HashMap<String, Value> = HashMap::new();
-        // Create directly in Sent - no draft needed
-        email_create.insert("mailboxIds".into(), json!({ sent.id.clone(): true }));
-        email_create.insert(
-            "from".into(),
-            json!([{ "email": identity.email, "name": identity.name }]),
-        );
-        email_create.insert(
-            "to".into(),
-            json!(
-                to.iter()
-                    .map(|a| json!({"email": a.email, "name": a.name}))
-                    .collect::<Vec<_>>()
-            ),
-        );
-        if !cc.is_empty() {
-            email_create.insert(
-                "cc".into(),
-                json!(
-                    cc.iter()
-                        .map(|a| json!({"email": a.email, "name": a.name}))
-                        .collect::<Vec<_>>()
-                ),
-            );
-        }
-        if !bcc.is_empty() {
-            email_create.insert(
-                "bcc".into(),
-                json!(
-                    bcc.iter()
-                        .map(|a| json!({"email": a.email, "name": a.name}))
-                        .collect::<Vec<_>>()
-                ),
-            );
-        }
-        email_create.insert("subject".into(), json!(subject));
-        email_create.insert(
-            "bodyValues".into(),
-            json!({ "body": { "value": body, "charset": "utf-8" } }),
-        );
-        email_create.insert(
-            "textBody".into(),
-            json!([{ "partId": "body", "type": "text/plain" }]),
-        );
-        if let Some(reply_id) = in_reply_to {
-            email_create.insert("inReplyTo".into(), json!([reply_id]));
-        }
-
-        let responses = self
-            .request(vec![
-                json!([
-                    "Email/set",
-                    {
-                        "accountId": account_id,
-                        "create": { "email": email_create }
-                    },
-                    "e0"
-                ]),
-                json!([
-                    "EmailSubmission/set",
-                    {
-                        "accountId": account_id,
-                        "create": {
-                            "submission": {
-                                "identityId": identity.id,
-                                "emailId": "#email"
-                            }
-                        },
-                        "onSuccessUpdateEmail": {
-                            "#submission": {
-                                "keywords/$seen": true
-                            }
-                        }
-                    },
-                    "s0"
-                ]),
-            ])
-            .await?;
-
+    fn parse_email_create_response(responses: &[Value]) -> Result<String> {
         let email_resp: EmailSetResponse =
             Self::parse_response(responses.first().unwrap_or(&Value::Null), "Email/set")?;
 
@@ -684,7 +678,7 @@ impl JmapClient {
             });
         }
 
-        let email_id = email_resp
+        email_resp
             .created
             .and_then(|c: HashMap<String, Value>| c.get("email").cloned())
             .and_then(|d: Value| {
@@ -696,9 +690,71 @@ impl JmapClient {
                 method: "Email/set".into(),
                 error_type: "unknown".into(),
                 description: "No email ID returned".into(),
-            })?;
+            })
+    }
 
-        debug!(email_id = %email_id, "Email sent successfully");
+    #[instrument(skip(self, body, params))]
+    pub async fn send_email(
+        &self,
+        to: Vec<EmailAddress>,
+        subject: &str,
+        body: &str,
+        in_reply_to: Option<&str>,
+        params: ComposeParams<'_>,
+    ) -> Result<String> {
+        let ctx = self.prepare_compose(params.from, params.draft).await?;
+
+        let mut email_create: HashMap<String, Value> = HashMap::new();
+        ctx.apply_to_email(&mut email_create);
+        email_create.insert(
+            "to".into(),
+            json!(
+                to.iter()
+                    .map(|a| json!({"email": a.email, "name": a.name}))
+                    .collect::<Vec<_>>()
+            ),
+        );
+        if !params.cc.is_empty() {
+            email_create.insert(
+                "cc".into(),
+                json!(
+                    params
+                        .cc
+                        .iter()
+                        .map(|a| json!({"email": a.email, "name": a.name}))
+                        .collect::<Vec<_>>()
+                ),
+            );
+        }
+        if !params.bcc.is_empty() {
+            email_create.insert(
+                "bcc".into(),
+                json!(
+                    params
+                        .bcc
+                        .iter()
+                        .map(|a| json!({"email": a.email, "name": a.name}))
+                        .collect::<Vec<_>>()
+                ),
+            );
+        }
+        email_create.insert("subject".into(), json!(subject));
+        email_create.insert(
+            "bodyValues".into(),
+            json!({ "body": { "value": body, "charset": "utf-8" } }),
+        );
+        email_create.insert(
+            "textBody".into(),
+            json!([{ "partId": "body", "type": "text/plain" }]),
+        );
+        if let Some(reply_id) = in_reply_to {
+            email_create.insert("inReplyTo".into(), json!([reply_id]));
+        }
+
+        let responses = self.request(ctx.build_method_calls(email_create)).await?;
+        let email_id = Self::parse_email_create_response(&responses)?;
+
+        debug!(email_id = %email_id, draft = params.draft, "Email created successfully");
         Ok(email_id)
     }
 
@@ -791,27 +847,22 @@ impl JmapClient {
     }
 
     /// Send a reply to an existing email with proper threading headers
-    #[instrument(skip(self, body))]
+    #[instrument(skip(self, body, params))]
     pub async fn reply_email(
         &self,
         original: &Email,
         body: &str,
         reply_all: bool,
-        cc: Vec<EmailAddress>,
-        bcc: Vec<EmailAddress>,
-        from: Option<&str>,
+        params: ComposeParams<'_>,
     ) -> Result<String> {
-        self.require_capability("urn:ietf:params:jmap:submission", "Email sending")?;
+        let ctx = self.prepare_compose(params.from, params.draft).await?;
 
-        let account_id = self
-            .session()?
-            .primary_account_id()
-            .ok_or_else(|| Error::Config("No primary account".into()))?;
-
-        let identity = self.resolve_identity(from).await?;
-        let my_email = identity.email.to_lowercase();
-
-        let sent = self.find_mailbox("sent").await?;
+        let my_email = ctx
+            .identity
+            .as_ref()
+            .map(|i| i.email.to_lowercase())
+            .or_else(|| params.from.map(|f| f.to_lowercase()))
+            .unwrap_or_default();
 
         // Build To: reply to sender, or if reply_all, include original recipients
         let mut to_addrs: Vec<EmailAddress> = original.from.clone().unwrap_or_default();
@@ -820,7 +871,7 @@ impl JmapClient {
             // Add original To recipients (except ourselves)
             if let Some(ref orig_to) = original.to {
                 for addr in orig_to {
-                    if addr.email.to_lowercase() != my_email {
+                    if my_email.is_empty() || addr.email.to_lowercase() != my_email {
                         to_addrs.push(addr.clone());
                     }
                 }
@@ -828,10 +879,10 @@ impl JmapClient {
         }
 
         // Build CC: include original CC recipients (if reply_all) plus any new CC
-        let mut cc_addrs = cc;
+        let mut cc_addrs = params.cc;
         if reply_all && let Some(ref orig_cc) = original.cc {
             for addr in orig_cc {
-                if addr.email.to_lowercase() != my_email {
+                if my_email.is_empty() || addr.email.to_lowercase() != my_email {
                     cc_addrs.push(addr.clone());
                 }
             }
@@ -862,12 +913,7 @@ impl JmapClient {
         };
 
         let mut email_create: HashMap<String, Value> = HashMap::new();
-        // Create directly in Sent - no draft needed
-        email_create.insert("mailboxIds".into(), json!({ sent.id.clone(): true }));
-        email_create.insert(
-            "from".into(),
-            json!([{ "email": identity.email, "name": identity.name }]),
-        );
+        ctx.apply_to_email(&mut email_create);
         email_create.insert(
             "to".into(),
             json!(
@@ -888,11 +934,13 @@ impl JmapClient {
                 ),
             );
         }
-        if !bcc.is_empty() {
+        if !params.bcc.is_empty() {
             email_create.insert(
                 "bcc".into(),
                 json!(
-                    bcc.iter()
+                    params
+                        .bcc
+                        .iter()
                         .map(|a| json!({"email": a.email, "name": a.name}))
                         .collect::<Vec<_>>()
                 ),
@@ -916,97 +964,23 @@ impl JmapClient {
             email_create.insert("references".into(), json!(references));
         }
 
-        let responses = self
-            .request(vec![
-                json!([
-                    "Email/set",
-                    {
-                        "accountId": account_id,
-                        "create": { "email": email_create }
-                    },
-                    "e0"
-                ]),
-                json!([
-                    "EmailSubmission/set",
-                    {
-                        "accountId": account_id,
-                        "create": {
-                            "submission": {
-                                "identityId": identity.id,
-                                "emailId": "#email"
-                            }
-                        },
-                        "onSuccessUpdateEmail": {
-                            "#submission": {
-                                "keywords/$seen": true
-                            }
-                        }
-                    },
-                    "s0"
-                ]),
-            ])
-            .await?;
+        let responses = self.request(ctx.build_method_calls(email_create)).await?;
+        let email_id = Self::parse_email_create_response(&responses)?;
 
-        let email_resp: EmailSetResponse =
-            Self::parse_response(responses.first().unwrap_or(&Value::Null), "Email/set")?;
-
-        if let Some(ref not_created) = email_resp.not_created
-            && let Some(err) = not_created.get("email")
-        {
-            let error_type = err
-                .get("type")
-                .and_then(|v: &Value| v.as_str())
-                .unwrap_or("unknown");
-            let description = err
-                .get("description")
-                .and_then(|v: &Value| v.as_str())
-                .unwrap_or("Failed to create email");
-            return Err(Error::Jmap {
-                method: "Email/set".into(),
-                error_type: error_type.into(),
-                description: description.into(),
-            });
-        }
-
-        let email_id = email_resp
-            .created
-            .and_then(|c: HashMap<String, Value>| c.get("email").cloned())
-            .and_then(|d: Value| {
-                d.get("id")
-                    .and_then(|v: &Value| v.as_str())
-                    .map(String::from)
-            })
-            .ok_or_else(|| Error::Jmap {
-                method: "Email/set".into(),
-                error_type: "unknown".into(),
-                description: "No email ID returned".into(),
-            })?;
-
-        debug!(email_id = %email_id, "Reply sent successfully");
+        debug!(email_id = %email_id, draft = params.draft, "Reply created successfully");
         Ok(email_id)
     }
 
     /// Forward an email with proper attribution
-    #[instrument(skip(self, body))]
+    #[instrument(skip(self, body, params))]
     pub async fn forward_email(
         &self,
         original: &Email,
         to: Vec<EmailAddress>,
         body: &str,
-        cc: Vec<EmailAddress>,
-        bcc: Vec<EmailAddress>,
-        from: Option<&str>,
+        params: ComposeParams<'_>,
     ) -> Result<String> {
-        self.require_capability("urn:ietf:params:jmap:submission", "Email sending")?;
-
-        let account_id = self
-            .session()?
-            .primary_account_id()
-            .ok_or_else(|| Error::Config("No primary account".into()))?;
-
-        let identity = self.resolve_identity(from).await?;
-
-        let sent = self.find_mailbox("sent").await?;
+        let ctx = self.prepare_compose(params.from, params.draft).await?;
 
         // Build subject with Fwd: prefix if not already present
         let subject = if original
@@ -1052,12 +1026,7 @@ impl JmapClient {
         );
 
         let mut email_create: HashMap<String, Value> = HashMap::new();
-        // Create directly in Sent - no draft needed
-        email_create.insert("mailboxIds".into(), json!({ sent.id.clone(): true }));
-        email_create.insert(
-            "from".into(),
-            json!([{ "email": identity.email, "name": identity.name }]),
-        );
+        ctx.apply_to_email(&mut email_create);
         email_create.insert(
             "to".into(),
             json!(
@@ -1066,21 +1035,25 @@ impl JmapClient {
                     .collect::<Vec<_>>()
             ),
         );
-        if !cc.is_empty() {
+        if !params.cc.is_empty() {
             email_create.insert(
                 "cc".into(),
                 json!(
-                    cc.iter()
+                    params
+                        .cc
+                        .iter()
                         .map(|a| json!({"email": a.email, "name": a.name}))
                         .collect::<Vec<_>>()
                 ),
             );
         }
-        if !bcc.is_empty() {
+        if !params.bcc.is_empty() {
             email_create.insert(
                 "bcc".into(),
                 json!(
-                    bcc.iter()
+                    params
+                        .bcc
+                        .iter()
                         .map(|a| json!({"email": a.email, "name": a.name}))
                         .collect::<Vec<_>>()
                 ),
@@ -1096,73 +1069,10 @@ impl JmapClient {
             json!([{ "partId": "body", "type": "text/plain" }]),
         );
 
-        let responses = self
-            .request(vec![
-                json!([
-                    "Email/set",
-                    {
-                        "accountId": account_id,
-                        "create": { "email": email_create }
-                    },
-                    "e0"
-                ]),
-                json!([
-                    "EmailSubmission/set",
-                    {
-                        "accountId": account_id,
-                        "create": {
-                            "submission": {
-                                "identityId": identity.id,
-                                "emailId": "#email"
-                            }
-                        },
-                        "onSuccessUpdateEmail": {
-                            "#submission": {
-                                "keywords/$seen": true
-                            }
-                        }
-                    },
-                    "s0"
-                ]),
-            ])
-            .await?;
+        let responses = self.request(ctx.build_method_calls(email_create)).await?;
+        let email_id = Self::parse_email_create_response(&responses)?;
 
-        let email_resp: EmailSetResponse =
-            Self::parse_response(responses.first().unwrap_or(&Value::Null), "Email/set")?;
-
-        if let Some(ref not_created) = email_resp.not_created
-            && let Some(err) = not_created.get("email")
-        {
-            let error_type = err
-                .get("type")
-                .and_then(|v: &Value| v.as_str())
-                .unwrap_or("unknown");
-            let description = err
-                .get("description")
-                .and_then(|v: &Value| v.as_str())
-                .unwrap_or("Failed to create email");
-            return Err(Error::Jmap {
-                method: "Email/set".into(),
-                error_type: error_type.into(),
-                description: description.into(),
-            });
-        }
-
-        let email_id = email_resp
-            .created
-            .and_then(|c: HashMap<String, Value>| c.get("email").cloned())
-            .and_then(|d: Value| {
-                d.get("id")
-                    .and_then(|v: &Value| v.as_str())
-                    .map(String::from)
-            })
-            .ok_or_else(|| Error::Jmap {
-                method: "Email/set".into(),
-                error_type: "unknown".into(),
-                description: "No email ID returned".into(),
-            })?;
-
-        debug!(email_id = %email_id, "Forward sent successfully");
+        debug!(email_id = %email_id, draft = params.draft, "Forward created successfully");
         Ok(email_id)
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,6 +141,10 @@ enum Commands {
         /// Send from a specific identity (email address). Use `list identities` to see available.
         #[arg(long)]
         from: Option<String>,
+
+        /// Save as draft instead of sending
+        #[arg(long)]
+        draft: bool,
     },
 
     /// Move email to a mailbox
@@ -215,6 +219,10 @@ enum Commands {
         /// Send from a specific identity (email address). Use `list identities` to see available.
         #[arg(long)]
         from: Option<String>,
+
+        /// Save as draft instead of sending
+        #[arg(long)]
+        draft: bool,
     },
 
     /// Forward an email
@@ -241,6 +249,10 @@ enum Commands {
         /// Send from a specific identity (email address). Use `list identities` to see available.
         #[arg(long)]
         from: Option<String>,
+
+        /// Save as draft instead of sending
+        #[arg(long)]
+        draft: bool,
     },
 
     /// Generate shell completions
@@ -408,15 +420,22 @@ async fn main() {
             bcc,
             reply_to,
             from,
+            draft,
         } => {
             commands::send(
                 &to,
                 &subject,
                 &body,
-                cc.as_deref(),
-                bcc.as_deref(),
                 reply_to.as_deref(),
-                from.as_deref(),
+                jmap::ComposeParams {
+                    cc: cc.as_deref().map(util::parse_addresses).unwrap_or_default(),
+                    bcc: bcc
+                        .as_deref()
+                        .map(util::parse_addresses)
+                        .unwrap_or_default(),
+                    from: from.as_deref(),
+                    draft,
+                },
             )
             .await
         }
@@ -455,14 +474,21 @@ async fn main() {
             cc,
             bcc,
             from,
+            draft,
         } => {
             commands::reply(
                 &email_id,
                 &body,
                 all,
-                cc.as_deref(),
-                bcc.as_deref(),
-                from.as_deref(),
+                jmap::ComposeParams {
+                    cc: cc.as_deref().map(util::parse_addresses).unwrap_or_default(),
+                    bcc: bcc
+                        .as_deref()
+                        .map(util::parse_addresses)
+                        .unwrap_or_default(),
+                    from: from.as_deref(),
+                    draft,
+                },
             )
             .await
         }
@@ -474,14 +500,21 @@ async fn main() {
             cc,
             bcc,
             from,
+            draft,
         } => {
             commands::forward(
                 &email_id,
                 &to,
                 &body,
-                cc.as_deref(),
-                bcc.as_deref(),
-                from.as_deref(),
+                jmap::ComposeParams {
+                    cc: cc.as_deref().map(util::parse_addresses).unwrap_or_default(),
+                    bcc: bcc
+                        .as_deref()
+                        .map(util::parse_addresses)
+                        .unwrap_or_default(),
+                    from: from.as_deref(),
+                    draft,
+                },
             )
             .await
         }

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -25,6 +25,19 @@ type ToolResult = std::result::Result<CallToolResult, McpError>;
 mod format;
 use format::*;
 
+// ============ Shared Types ============
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum SendAction {
+    /// Preview the email before sending
+    Preview,
+    /// Send the email
+    Confirm,
+    /// Save as draft without sending
+    Draft,
+}
+
 // ============ Request Types ============
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
@@ -112,8 +125,8 @@ pub struct MarkAsSpamRequest {
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct SendEmailRequest {
-    /// 'preview' to see the draft, 'confirm' to send - ALWAYS preview first
-    pub action: String,
+    /// 'preview' to see the draft, 'confirm' to send, 'draft' to save as draft without sending - ALWAYS preview first
+    pub action: SendAction,
     /// Recipient email address(es), comma-separated
     pub to: String,
     /// Email subject line
@@ -133,8 +146,8 @@ pub struct SendEmailRequest {
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct ReplyEmailRequest {
-    /// 'preview' to see the draft, 'confirm' to send - ALWAYS preview first
-    pub action: String,
+    /// 'preview' to see the draft, 'confirm' to send, 'draft' to save as draft without sending - ALWAYS preview first
+    pub action: SendAction,
     /// The email ID to reply to
     pub email_id: String,
     /// Reply body text (your response, without quoting original)
@@ -155,8 +168,8 @@ pub struct ReplyEmailRequest {
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct ForwardEmailRequest {
-    /// 'preview' to see the draft, 'confirm' to send - ALWAYS preview first
-    pub action: String,
+    /// 'preview' to see the draft, 'confirm' to send, 'draft' to save as draft without sending - ALWAYS preview first
+    pub action: SendAction,
     /// The email ID to forward
     pub email_id: String,
     /// Recipient email address(es), comma-separated
@@ -534,7 +547,7 @@ impl FastmailMcp {
     // ============ Send/Reply/Forward Tools ============
 
     #[tool(
-        description = "Compose and send a new email. CRITICAL: You MUST call with action='preview' first, show the user the draft, get explicit approval, then call again with action='confirm'. NEVER skip the preview step."
+        description = "Compose and send a new email. CRITICAL: You MUST call with action='preview' first, show the user the draft, get explicit approval, then call again with action='confirm' to send or action='draft' to save as a draft without sending. NEVER skip the preview step."
     )]
     async fn send_email(&self, Parameters(req): Parameters<SendEmailRequest>) -> ToolResult {
         let to_addrs = parse_addresses(&req.to);
@@ -549,7 +562,7 @@ impl FastmailMcp {
             .map(|s| parse_addresses(s))
             .unwrap_or_default();
 
-        if req.action == "preview" {
+        if matches!(req.action, SendAction::Preview) {
             return Self::text_result(format!(
                 "EMAIL PREVIEW - Review before sending:\n\n\
                 To: {}\n\
@@ -559,7 +572,8 @@ impl FastmailMcp {
                 --- Body ---\n\
                 {}\n\n\
                 ---\n\
-                To send this email, call this tool again with action: \"confirm\" and the same parameters.",
+                To send this email, call this tool again with action: \"confirm\" and the same parameters.\n\
+                To save as draft without sending, use action: \"draft\".",
                 format_address_list(Some(&to_addrs)),
                 if cc_addrs.is_empty() {
                     "(none)".to_string()
@@ -576,34 +590,43 @@ impl FastmailMcp {
             ));
         }
 
+        let draft = matches!(req.action, SendAction::Draft);
         let client = self.client.lock().await;
         match client
             .send_email(
                 to_addrs.clone(),
-                cc_addrs,
-                bcc_addrs,
                 &req.subject,
                 &req.body,
                 None,
-                req.from.as_deref(),
+                crate::jmap::ComposeParams {
+                    cc: cc_addrs,
+                    bcc: bcc_addrs,
+                    from: req.from.as_deref(),
+                    draft,
+                },
             )
             .await
         {
             Ok(email_id) => Self::text_result(format!(
-                "Email sent successfully!\n\
+                "Email {} successfully!\n\
                 To: {}\n\
                 Subject: {}\n\
                 Email ID: {}",
+                if draft { "saved as draft" } else { "sent" },
                 format_address_list(Some(&to_addrs)),
                 req.subject,
                 email_id
             )),
-            Err(e) => Self::error_result(format!("Failed to send email: {}", e)),
+            Err(e) => Self::error_result(format!(
+                "Failed to {} email: {}",
+                if draft { "draft" } else { "send" },
+                e
+            )),
         }
     }
 
     #[tool(
-        description = "Reply to an existing email thread. CRITICAL: You MUST call with action='preview' first, show the user the draft, get explicit approval, then call again with action='confirm'. NEVER skip the preview step. For reply-all, set all=true."
+        description = "Reply to an existing email thread. CRITICAL: You MUST call with action='preview' first, show the user the draft, get explicit approval, then call again with action='confirm' to send or action='draft' to save as a draft without sending. NEVER skip the preview step. For reply-all, set all=true."
     )]
     async fn reply_to_email(&self, Parameters(req): Parameters<ReplyEmailRequest>) -> ToolResult {
         let client = self.client.lock().await;
@@ -639,7 +662,7 @@ impl FastmailMcp {
         // Determine recipients
         let to_addrs: Vec<EmailAddress> = original.from.clone().unwrap_or_default();
 
-        if req.action == "preview" {
+        if matches!(req.action, SendAction::Preview) {
             return Self::text_result(format!(
                 "REPLY PREVIEW - Review before sending:\n\n\
                 To: {}\n\
@@ -650,7 +673,8 @@ impl FastmailMcp {
                 --- Your Reply ---\n\
                 {}\n\n\
                 ---\n\
-                To send this reply, call this tool again with action: \"confirm\" and the same parameters.",
+                To send this reply, call this tool again with action: \"confirm\" and the same parameters.\n\
+                To save as draft without sending, use action: \"draft\".",
                 format_address_list(Some(&to_addrs)),
                 if cc_addrs.is_empty() {
                     "(none)".to_string()
@@ -672,32 +696,41 @@ impl FastmailMcp {
             ));
         }
 
+        let draft = matches!(req.action, SendAction::Draft);
         match client
             .reply_email(
                 &original,
                 &req.body,
                 reply_all,
-                cc_addrs,
-                bcc_addrs,
-                req.from.as_deref(),
+                crate::jmap::ComposeParams {
+                    cc: cc_addrs,
+                    bcc: bcc_addrs,
+                    from: req.from.as_deref(),
+                    draft,
+                },
             )
             .await
         {
             Ok(email_id) => Self::text_result(format!(
-                "Reply sent successfully!\n\
+                "Reply {} successfully!\n\
                 To: {}\n\
                 Subject: {}\n\
                 Email ID: {}",
+                if draft { "saved as draft" } else { "sent" },
                 format_address_list(Some(&to_addrs)),
                 subject,
                 email_id
             )),
-            Err(e) => Self::error_result(format!("Failed to send reply: {}", e)),
+            Err(e) => Self::error_result(format!(
+                "Failed to {} reply: {}",
+                if draft { "draft" } else { "send" },
+                e
+            )),
         }
     }
 
     #[tool(
-        description = "Forward an email to new recipients. CRITICAL: You MUST call with action='preview' first, show the user the draft, get explicit approval, then call again with action='confirm'. NEVER skip the preview step."
+        description = "Forward an email to new recipients. CRITICAL: You MUST call with action='preview' first, show the user the draft, get explicit approval, then call again with action='confirm' to send or action='draft' to save as a draft without sending. NEVER skip the preview step."
     )]
     async fn forward_email(&self, Parameters(req): Parameters<ForwardEmailRequest>) -> ToolResult {
         let client = self.client.lock().await;
@@ -741,7 +774,7 @@ impl FastmailMcp {
 
         let sender = format_address_list(original.from.as_ref());
 
-        if req.action == "preview" {
+        if matches!(req.action, SendAction::Preview) {
             return Self::text_result(format!(
                 "FORWARD PREVIEW - Review before sending:\n\n\
                 To: {}\n\
@@ -757,7 +790,8 @@ impl FastmailMcp {
                 Subject: {}\n\n\
                 {}\n\n\
                 ---\n\
-                To send this forward, call this tool again with action: \"confirm\" and the same parameters.",
+                To send this forward, call this tool again with action: \"confirm\" and the same parameters.\n\
+                To save as draft without sending, use action: \"draft\".",
                 format_address_list(Some(&to_addrs)),
                 if cc_addrs.is_empty() {
                     "(none)".to_string()
@@ -779,27 +813,36 @@ impl FastmailMcp {
             ));
         }
 
+        let draft = matches!(req.action, SendAction::Draft);
         match client
             .forward_email(
                 &original,
                 to_addrs.clone(),
                 body,
-                cc_addrs,
-                bcc_addrs,
-                req.from.as_deref(),
+                crate::jmap::ComposeParams {
+                    cc: cc_addrs,
+                    bcc: bcc_addrs,
+                    from: req.from.as_deref(),
+                    draft,
+                },
             )
             .await
         {
             Ok(email_id) => Self::text_result(format!(
-                "Email forwarded successfully!\n\
+                "Forward {} successfully!\n\
                 To: {}\n\
                 Subject: {}\n\
                 Email ID: {}",
+                if draft { "saved as draft" } else { "sent" },
                 format_address_list(Some(&to_addrs)),
                 subject,
                 email_id
             )),
-            Err(e) => Self::error_result(format!("Failed to forward email: {}", e)),
+            Err(e) => Self::error_result(format!(
+                "Failed to {} forward: {}",
+                if draft { "draft" } else { "send" },
+                e
+            )),
         }
     }
 


### PR DESCRIPTION
## Summary

Fix-merge of community PR #9 from @thrawny (Jonas Lergell) with audit findings addressed:

- **SendAction enum**: MCP `action` field is now a proper enum (`preview`/`confirm`/`draft`) instead of bare `String`
- **ComposeParams struct**: Eliminates `clippy::too_many_arguments` across send/reply/forward, removes `#[allow]` attributes
- **Shared draft/send helper**: `ComposeContext` extracts ~50 lines of duplicated branching (mailbox selection, identity resolution, method_calls building) into reusable helpers
- **Fix missing `from` on drafts**: Always attempts `resolve_identity(from)` — uses it if available, gracefully skips on failure for drafts
- **Fix reply-all empty recipients bug**: Guards `my_email.is_empty()` check so empty string doesn't filter out all recipients
- **$seen keyword on drafts**: Drafts now get both `$draft` and `$seen` keywords
- **MCP preview text updated**: All 3 handlers mention `action='draft'` option
- **CLI output differentiation**: JSON output includes `status: "draft"` or `status: "sent"`

## Test plan

- [x] `cargo build` — clean
- [x] `cargo clippy -- -D warnings` — zero warnings, no `#[allow]` attributes
- [x] `cargo fmt --check` — formatted
- [x] `cargo test` — 33/33 pass

Co-Authored-By: Jonas Lergell <jonaslergell@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)