### PR TITLE
feat: add /fastmail Claude Code skills

### DIFF
--- a/.claude/skills/fastmail.md
+++ b/.claude/skills/fastmail.md
@@ -1,3 +1,8 @@
+---
+name: fastmail
+description: Complete reference for fastmail-cli — all commands, flags, config, and common patterns
+---
+
 # fastmail-cli — Complete Reference
 
 fastmail-cli is a Rust CLI for Fastmail via JMAP (email) and CardDAV (contacts). All output is JSON: `{"success": true, "data": {...}}`.

--- a/.claude/skills/fastmail.md
+++ b/.claude/skills/fastmail.md
@@ -1,0 +1,132 @@
+# fastmail-cli — Complete Reference
+
+fastmail-cli is a Rust CLI for Fastmail via JMAP (email) and CardDAV (contacts). All output is JSON: `{"success": true, "data": {...}}`.
+
+## Setup
+
+```bash
+fastmail-cli auth fmu1-YOUR-TOKEN
+```
+
+Config lives at `~/.config/fastmail-cli/config.toml`:
+```toml
+[core]
+api_token = "fmu1-..."
+
+[contacts]
+username = "you@fastmail.com"
+app_password = "xxxx..."
+```
+
+Or via env: `FASTMAIL_API_TOKEN`, `FASTMAIL_USERNAME`, `FASTMAIL_APP_PASSWORD`
+
+Debug: `RUST_LOG=debug fastmail-cli [cmd]`
+
+---
+
+## Command Reference
+
+### List
+
+```bash
+fastmail-cli list emails [-m MAILBOX] [-l LIMIT]     # default: INBOX, 50
+fastmail-cli list mailboxes
+fastmail-cli list identities                          # sender aliases for --from
+```
+
+### Get & Thread
+
+```bash
+fastmail-cli get EMAIL_ID                            # full email with body
+fastmail-cli thread EMAIL_ID                         # entire conversation
+```
+
+### Search
+
+```bash
+fastmail-cli search [OPTIONS]
+  --text/-t STR       # full-text (from/to/subject/body)
+  --from/--to/--cc/--bcc/--subject/--body STR
+  --mailbox/-m STR
+  --before/--after STR  # ISO 8601: 2024-01-15
+  --unread --flagged --has-attachment
+  --min-size/--max-size BYTES
+  --limit/-l N        # default 50
+```
+
+### Compose
+
+```bash
+fastmail-cli send --to ADDR --subject SUBJ --body BODY [--cc] [--bcc] [--from IDENTITY] [--draft]
+fastmail-cli reply EMAIL_ID --body BODY [--all] [--cc] [--bcc] [--from IDENTITY] [--draft]
+fastmail-cli forward EMAIL_ID --to ADDR [--body STR] [--cc] [--bcc] [--from IDENTITY] [--draft]
+```
+
+### Manage
+
+```bash
+fastmail-cli move EMAIL_ID --to MAILBOX
+fastmail-cli mark-read EMAIL_ID [--unread]
+fastmail-cli spam EMAIL_ID [-y]
+```
+
+### Attachments
+
+```bash
+fastmail-cli download EMAIL_ID [-o OUTPUT_DIR] [-f raw|json] [--max-size 1M]
+```
+
+### Masked Email
+
+```bash
+fastmail-cli masked list
+fastmail-cli masked create [--domain URL] [--description STR] [--prefix STR]
+fastmail-cli masked enable/disable/delete ID [-y]
+```
+
+### Contacts
+
+```bash
+fastmail-cli contacts list
+fastmail-cli contacts search QUERY    # name, email, or org
+```
+
+### Other
+
+```bash
+fastmail-cli completions bash|zsh|fish|powershell
+fastmail-cli mcp    # start MCP server for Claude Desktop
+```
+
+---
+
+## Common Patterns
+
+```bash
+# Find unread emails from a sender
+fastmail-cli search --from boss@company.com --unread
+
+# Get a thread then reply
+fastmail-cli thread abc123
+fastmail-cli reply abc123 --body "Thanks, will do." --from work@me.com
+
+# Save draft instead of sending
+fastmail-cli send --to x@y.com --subject "Draft" --body "..." --draft
+
+# Download all attachments from an email
+fastmail-cli download abc123 -o ~/Downloads
+
+# Move to folder after reading
+fastmail-cli move abc123 --to "Archive"
+```
+
+---
+
+## Subcommand Skills
+
+- `/fastmail/search` — search workflows and filter combinations
+- `/fastmail/compose` — send, reply, forward, drafts, identities
+- `/fastmail/conversations` — threading, listing, reading
+- `/fastmail/attachments` — downloading and extracting attachments
+- `/fastmail/masked` — masked email management
+- `/fastmail/contacts` — contact search

--- a/.claude/skills/fastmail/attachments.md
+++ b/.claude/skills/fastmail/attachments.md
@@ -1,0 +1,54 @@
+# fastmail-cli — Attachments
+
+## Download Attachments
+
+```bash
+fastmail-cli download EMAIL_ID [OPTIONS]
+```
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--output` | `-o` | Output directory (default: current dir) |
+| `--format` | `-f` | `raw` (save files) or `json` (extract text content) |
+| `--max-size` | | Max image size before resizing (e.g. `500K`, `1M`) |
+
+## Examples
+
+```bash
+# Download all attachments to current directory
+fastmail-cli download abc123
+
+# Download to specific folder
+fastmail-cli download abc123 -o ~/Downloads/invoices
+
+# Extract text content as JSON (good for parsing docs/PDFs)
+fastmail-cli download abc123 -f json
+
+# Resize large images during download
+fastmail-cli download abc123 --max-size 800K -o ~/Downloads
+```
+
+## Format Details
+
+**`raw`** (default): Saves attachment files to disk as-is.
+
+**`json`**: Extracts text from attachments using kreuzberg (supports 56+ formats including PDF, DOCX, XLSX, images with OCR, etc.). Returns structured JSON with content and detected language — useful for agents that need to read document contents without saving files.
+
+## Workflow: Find Emails with Attachments Then Download
+
+```bash
+# Find emails with attachments
+fastmail-cli search --has-attachment --from invoices@vendor.com
+
+# Download attachments from a specific email
+fastmail-cli download EMAIL_ID -o ~/Documents/invoices
+
+# Or extract text for processing
+fastmail-cli download EMAIL_ID -f json | jq '.data[].content'
+```
+
+## Tips
+
+- `get EMAIL_ID` includes attachment metadata (names, sizes, content types) without downloading — check what's there before downloading.
+- Use `-f json` when you need to read document content programmatically; use `raw` when you need the actual files.
+- `--max-size` is useful for emails with many large images where you only need thumbnails.

--- a/.claude/skills/fastmail/attachments.md
+++ b/.claude/skills/fastmail/attachments.md
@@ -1,3 +1,8 @@
+---
+name: fastmail/attachments
+description: fastmail-cli download — save attachments or extract text content from emails
+---
+
 # fastmail-cli — Attachments
 
 ## Download Attachments

--- a/.claude/skills/fastmail/compose.md
+++ b/.claude/skills/fastmail/compose.md
@@ -1,3 +1,8 @@
+---
+name: fastmail/compose
+description: fastmail-cli send, reply, forward, draft — flags, identities, and compose patterns
+---
+
 # fastmail-cli — Compose (Send / Reply / Forward / Draft)
 
 ## Identities

--- a/.claude/skills/fastmail/compose.md
+++ b/.claude/skills/fastmail/compose.md
@@ -1,0 +1,91 @@
+# fastmail-cli — Compose (Send / Reply / Forward / Draft)
+
+## Identities
+
+Before composing, check available sender identities:
+
+```bash
+fastmail-cli list identities
+```
+
+Use the identity email string with `--from` on any compose command.
+
+---
+
+## Send
+
+```bash
+fastmail-cli send \
+  --to "alice@example.com,bob@example.com" \
+  --subject "Subject line" \
+  --body "Plain text body" \
+  [--cc "cc@example.com"] \
+  [--bcc "bcc@example.com"] \
+  [--from "alias@yourdomain.com"] \
+  [--draft]
+```
+
+- `--to`, `--subject`, `--body` are required.
+- Multiple recipients: comma-separated string.
+- `--draft` saves to Drafts instead of sending.
+
+## Reply
+
+```bash
+fastmail-cli reply EMAIL_ID \
+  --body "Reply text" \
+  [--all] \
+  [--cc "extra@example.com"] \
+  [--bcc "hidden@example.com"] \
+  [--from "alias@yourdomain.com"] \
+  [--draft]
+```
+
+- `EMAIL_ID` is the email you're replying to (from `list`, `search`, or `thread`).
+- `--all` replies to all recipients (reply-all).
+- Threading headers (`In-Reply-To`, `References`) are set automatically.
+
+## Forward
+
+```bash
+fastmail-cli forward EMAIL_ID \
+  --to "recipient@example.com" \
+  [--body "Here's that email I mentioned..."] \
+  [--cc "cc@example.com"] \
+  [--bcc "bcc@example.com"] \
+  [--from "alias@yourdomain.com"] \
+  [--draft]
+```
+
+- `--body` is optional — text appears before the forwarded content.
+
+---
+
+## Common Patterns
+
+```bash
+# Reply from a specific alias
+fastmail-cli list identities
+fastmail-cli reply abc123 --body "On it." --from work-alias@mydomain.com
+
+# Reply-all and BCC someone for records
+fastmail-cli reply abc123 --body "Thanks all." --all --bcc archive@mydomain.com
+
+# Save a draft to review before sending
+fastmail-cli send --to x@y.com --subject "Careful email" --body "..." --draft
+
+# Forward with context note
+fastmail-cli forward abc123 --to manager@company.com --body "FYI, see below."
+
+# Quick reply inline
+fastmail-cli reply $(fastmail-cli search --from boss@co.com --unread | jq -r '.data[0].id') \
+  --body "Done."
+```
+
+---
+
+## Notes
+
+- Body is plain text only.
+- For HTML or complex formatting, compose in Fastmail web and use `--draft` to stage.
+- `--from` must match an identity returned by `list identities` — arbitrary addresses won't work.

--- a/.claude/skills/fastmail/contacts.md
+++ b/.claude/skills/fastmail/contacts.md
@@ -1,3 +1,8 @@
+---
+name: fastmail/contacts
+description: fastmail-cli contacts — CardDAV setup, list and search contacts
+---
+
 # fastmail-cli — Contacts
 
 Contacts use CardDAV and require separate credentials from the JMAP API token.

--- a/.claude/skills/fastmail/contacts.md
+++ b/.claude/skills/fastmail/contacts.md
@@ -1,0 +1,51 @@
+# fastmail-cli — Contacts
+
+Contacts use CardDAV and require separate credentials from the JMAP API token.
+
+## Configuration
+
+```toml
+# ~/.config/fastmail-cli/config.toml
+[contacts]
+username = "you@fastmail.com"
+app_password = "your-app-password"
+```
+
+Or via env:
+```bash
+FASTMAIL_USERNAME="you@fastmail.com"
+FASTMAIL_APP_PASSWORD="your-app-password"
+```
+
+Generate an app password at: Fastmail Settings → Privacy & Security → App Passwords
+
+## Commands
+
+```bash
+# List all contacts
+fastmail-cli contacts list
+
+# Search by name, email, or organization
+fastmail-cli contacts search "Alice"
+fastmail-cli contacts search "acme.com"
+fastmail-cli contacts search "ACME Corp"
+```
+
+## Typical Patterns
+
+```bash
+# Find email address before composing
+fastmail-cli contacts search "Bob Smith" | jq '.data[0].emails[0].value'
+
+# Verify who someone is before replying
+fastmail-cli contacts search "bob@unknown.com"
+
+# Find all contacts at a company
+fastmail-cli contacts search "bigcorp.com"
+```
+
+## Notes
+
+- `contacts list` returns all contacts — can be large. Prefer `contacts search` for targeted lookups.
+- Contact data includes name, emails, phone numbers, organization, and notes where available.
+- Read-only via CLI — create/edit contacts through Fastmail web or a CardDAV client.

--- a/.claude/skills/fastmail/conversations.md
+++ b/.claude/skills/fastmail/conversations.md
@@ -1,0 +1,82 @@
+# fastmail-cli — Conversations & Email Reading
+
+## Listing Emails
+
+```bash
+fastmail-cli list emails [-m MAILBOX] [-l LIMIT]
+```
+
+- Default mailbox: `INBOX`, default limit: `50`
+- Returns email summaries (id, subject, from, date, flags)
+
+```bash
+# List a different folder
+fastmail-cli list emails --mailbox "Sent"
+fastmail-cli list emails --mailbox "Archive" --limit 100
+
+# See all folders first
+fastmail-cli list mailboxes
+```
+
+## Reading a Single Email
+
+```bash
+fastmail-cli get EMAIL_ID
+```
+
+Returns full email: headers, body (plain + HTML), attachment metadata.
+
+## Reading a Full Thread/Conversation
+
+```bash
+fastmail-cli thread EMAIL_ID
+```
+
+- Provide **any** email ID in the thread — returns all messages in chronological order.
+- Ideal for understanding full context before replying.
+
+## Typical Read Workflow
+
+```bash
+# 1. List inbox
+fastmail-cli list emails
+
+# 2. Get a specific email by ID
+fastmail-cli get abc123
+
+# 3. Get full thread for context
+fastmail-cli thread abc123
+
+# 4. Mark as read when done
+fastmail-cli mark-read abc123
+
+# 5. Reply or move
+fastmail-cli reply abc123 --body "Got it, thanks."
+fastmail-cli move abc123 --to "Archive"
+```
+
+## Mark Read / Unread
+
+```bash
+fastmail-cli mark-read EMAIL_ID          # mark as read
+fastmail-cli mark-read EMAIL_ID --unread # mark as unread
+```
+
+## Triage
+
+```bash
+# Move to folder
+fastmail-cli move EMAIL_ID --to "Work/Projects"
+
+# Mark as spam (prompts confirmation)
+fastmail-cli spam EMAIL_ID
+
+# Skip confirmation
+fastmail-cli spam EMAIL_ID -y
+```
+
+## Tips
+
+- Use `search` to find emails, then `thread` to get full context — this is the most useful combo for agents.
+- `thread` is cheaper than running multiple `get` calls for each message in a conversation.
+- IDs are stable — safe to store and reference later.

--- a/.claude/skills/fastmail/conversations.md
+++ b/.claude/skills/fastmail/conversations.md
@@ -1,3 +1,8 @@
+---
+name: fastmail/conversations
+description: fastmail-cli list, get, thread — reading emails, conversations, mark-read, and triage
+---
+
 # fastmail-cli — Conversations & Email Reading
 
 ## Listing Emails

--- a/.claude/skills/fastmail/masked.md
+++ b/.claude/skills/fastmail/masked.md
@@ -1,3 +1,8 @@
+---
+name: fastmail/masked
+description: fastmail-cli masked — create, list, enable, disable, and delete masked email addresses
+---
+
 # fastmail-cli — Masked Email
 
 Masked emails are Fastmail's disposable address feature — each masked address forwards to your real inbox and can be disabled or deleted independently.

--- a/.claude/skills/fastmail/masked.md
+++ b/.claude/skills/fastmail/masked.md
@@ -1,0 +1,62 @@
+# fastmail-cli — Masked Email
+
+Masked emails are Fastmail's disposable address feature — each masked address forwards to your real inbox and can be disabled or deleted independently.
+
+## Commands
+
+```bash
+fastmail-cli masked list
+fastmail-cli masked create [--domain URL] [--description STR] [--prefix STR]
+fastmail-cli masked enable ID
+fastmail-cli masked disable ID
+fastmail-cli masked delete ID [-y]
+```
+
+## Create a Masked Email
+
+```bash
+# Basic (auto-generated address)
+fastmail-cli masked create
+
+# With context metadata
+fastmail-cli masked create \
+  --domain "https://example.com" \
+  --description "Example site signup" \
+  --prefix "example_shop"
+```
+
+- `--prefix`: custom address prefix, max 64 chars, `a-z`, `0-9`, `_` only
+- `--domain`: the site it's for (metadata only, not enforced)
+- `--description`: human-readable label
+
+## Manage Existing Masked Addresses
+
+```bash
+# See all masked addresses with their IDs and status
+fastmail-cli masked list
+
+# Temporarily stop forwarding (keep address, bounce/drop inbound)
+fastmail-cli masked disable MASKED_ID
+
+# Re-enable
+fastmail-cli masked enable MASKED_ID
+
+# Permanently delete
+fastmail-cli masked delete MASKED_ID
+fastmail-cli masked delete MASKED_ID -y   # skip confirmation
+```
+
+## Typical Patterns
+
+```bash
+# Create a throwaway for a signup
+fastmail-cli masked create --description "Newsletter signup" --prefix "news_acme"
+
+# Getting spam? Disable immediately
+fastmail-cli masked list  # find the ID
+fastmail-cli masked disable abc-masked-id
+
+# Clean up old ones
+fastmail-cli masked list | jq '.data[] | select(.description | test("old")) | .id'
+fastmail-cli masked delete OLD_ID -y
+```

--- a/.claude/skills/fastmail/search.md
+++ b/.claude/skills/fastmail/search.md
@@ -1,3 +1,8 @@
+---
+name: fastmail/search
+description: fastmail-cli search — all filter flags, date ranges, and search workflow patterns
+---
+
 # fastmail-cli — Search
 
 Search filters are ANDed together. All return JSON with a `data` array of email summaries.

--- a/.claude/skills/fastmail/search.md
+++ b/.claude/skills/fastmail/search.md
@@ -1,0 +1,60 @@
+# fastmail-cli — Search
+
+Search filters are ANDed together. All return JSON with a `data` array of email summaries.
+
+## Syntax
+
+```bash
+fastmail-cli search [OPTIONS]
+```
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--text` | `-t` | Full-text: from, to, cc, bcc, subject, body |
+| `--from` | | Filter by From header |
+| `--to` | | Filter by To header |
+| `--cc` | | Filter by Cc header |
+| `--bcc` | | Filter by Bcc header |
+| `--subject` | | Filter by Subject |
+| `--body` | | Filter by body text |
+| `--mailbox` | `-m` | Restrict to mailbox (default: all) |
+| `--after` | | On/after date (ISO 8601: `2024-01-15`) |
+| `--before` | | Before date (ISO 8601: `2024-01-15`) |
+| `--unread` | | Unread only |
+| `--flagged` | | Flagged/starred only |
+| `--has-attachment` | | Must have attachments |
+| `--min-size` | | Minimum size in bytes |
+| `--max-size` | | Maximum size in bytes |
+| `--limit` | `-l` | Max results (default: 50) |
+
+## Examples
+
+```bash
+# Simple full-text search
+fastmail-cli search --text "invoice"
+
+# From a specific sender, unread only
+fastmail-cli search --from boss@company.com --unread
+
+# Subject keyword in a specific folder
+fastmail-cli search --subject "deployment" --mailbox "Work"
+
+# Date range
+fastmail-cli search --after 2024-01-01 --before 2024-02-01
+
+# Emails with attachments over 1MB
+fastmail-cli search --has-attachment --min-size 1048576
+
+# Recent flagged emails
+fastmail-cli search --flagged --after 2024-01-01 --limit 20
+
+# Find a thread starter to then get full conversation
+fastmail-cli search --subject "Project Kickoff" --from alice@example.com
+# then: fastmail-cli thread EMAIL_ID
+```
+
+## Tips
+
+- `--text` is the catch-all; use specific flags (`--from`, `--subject`) when you know what field to target — it's faster and more precise.
+- Chain with `thread EMAIL_ID` to get full conversation context after finding an email.
+- IDs from search output can be passed directly to `get`, `reply`, `forward`, `move`, `download`.

--- a/README.md
+++ b/README.md
@@ -324,6 +324,24 @@ fastmail-cli list emails | jq '.data.emails[].subject'
 fastmail-cli get EMAIL_ID | jq -r '.data.bodyValues | to_entries[0].value.value'
 ```
 
+## Claude Code Skills
+
+If you're using [Claude Code](https://claude.ai/claude-code), this repo ships skills that teach agents how to use the CLI — no need to explain flags or workflows manually.
+
+Copy the skills into your project's `.claude/skills/` directory (or anywhere Claude Code loads skills from), then invoke them:
+
+```
+/fastmail              # full command reference + common patterns
+/fastmail/search       # search filters, date ranges, workflows
+/fastmail/compose      # send, reply, forward, drafts, identities
+/fastmail/conversations # list, get, thread, mark-read, triage
+/fastmail/attachments  # download, raw vs json, text extraction
+/fastmail/masked       # masked email CRUD
+/fastmail/contacts     # CardDAV setup, list/search
+```
+
+Skills are in `.claude/skills/` in this repo. Each one includes concrete examples and agent-oriented workflow patterns.
+
 ## MCP Server (Claude Integration)
 
 Run as an MCP server for use with Claude Desktop or other MCP clients:


### PR DESCRIPTION
Fixes https://github.com/radiosilence/fastmail-cli/issues/5

## Summary

- Adds `/fastmail` global skill — complete command reference, all flags, common patterns
- Adds 6 focused subcommand skills: `search`, `compose`, `conversations`, `attachments`, `masked`, `contacts`
- Skills live in `.claude/skills/fastmail/` so CC agents can invoke them by name
- Each skill has concrete examples and workflow patterns, not just flag lists

Closes #5

## Skills added

| Skill | Covers |
|-------|--------|
| `/fastmail` | Full cheatsheet — every command, setup, config |
| `/fastmail/search` | All search filters, date ranges, flag combos |
| `/fastmail/compose` | send/reply/forward, identities, drafts |
| `/fastmail/conversations` | list/get/thread, mark-read, triage |
| `/fastmail/attachments` | download, raw vs json format, text extraction |
| `/fastmail/masked` | masked email CRUD |
| `/fastmail/contacts` | CardDAV setup, list/search |

🤖 Generated with [Claude Code](https://claude.com/claude-code)