### PR TITLE
feat: multipart HTML email and attachment support

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,22 @@
+# fastmail-cli Skills Fork
+
+This is jfdasher's fork of radiosilence/fastmail-cli, maintained primarily to host customized Claude Code skills for email management via `fastmail-cli`.
+
+## Account
+
+The configured Fastmail account is **jfd@thermopylae.com**.
+
+## Skills
+
+Skills live in `.claude/skills/` and are symlinked into `~/.claude/skills/` for global availability. The parent skill is `fastmail.md` with sub-skills in `fastmail/`.
+
+### Guardrail Policy
+
+- **Compose operations** (send, reply, forward) require user confirmation before executing. Ambiguous compose requests default to `--draft`.
+- **Triage operations** (move, spam, mark-read) are ungated — the user wants these usable in bulk without per-item confirmation.
+- **Mass sending is forbidden** — no loops or pipelines that send/reply/forward to multiple items.
+- The `-y` flag should not be passed to skip CLI confirmation prompts.
+
+## Permissions
+
+Global permissions in `~/.claude/settings.json` auto-allow all read and triage commands. `send`, `reply`, and `forward` are deliberately omitted so Claude Code's permission system acts as the confirmation gate.

--- a/.claude/skills/fastmail.md
+++ b/.claude/skills/fastmail.md
@@ -1,11 +1,28 @@
 ---
 name: fastmail
-description: Complete reference for fastmail-cli — all commands, flags, config, and common patterns
+description: Email management via fastmail-cli — read, search, compose, triage, contacts, and masked email for jfd@thermopylae.com. Invoke when the user asks about email, messages, inbox, or contacts.
+allowed-tools: Bash
 ---
 
 # fastmail-cli — Complete Reference
 
-fastmail-cli is a Rust CLI for Fastmail via JMAP (email) and CardDAV (contacts). All output is JSON: `{"success": true, "data": {...}}`.
+fastmail-cli is a Rust CLI for Fastmail via JMAP (email) and CardDAV (contacts). All output is JSON: `{"success": true, "data": {...}}`. The user's account is **jfd@thermopylae.com**.
+
+## Safety Rules
+
+### Compose Operations Require Confirmation
+
+Before executing `send`, `reply`, or `forward` without `--draft`: display the full command to the user — including all recipients, subject, and body — and ask "Should I send this?" Wait for explicit yes.
+
+When intent is ambiguous ("write a reply", "draft an email"), default to `--draft`. Only omit `--draft` when the user clearly intends to send immediately.
+
+### Mass-Destructive Operations Are Forbidden
+
+**Never** iterate over search or list results to apply destructive operations to multiple emails. No loops, xargs pipelines, or shell scripts that apply `send`, `reply`, or `forward` to multiple items. If the user asks for bulk sending, explain this must be done via the Fastmail web interface.
+
+### Never Skip CLI Confirmation Prompts
+
+Never pass `-y` or `--yes` to bypass the CLI's built-in confirmation prompts.
 
 ## Setup
 
@@ -72,7 +89,7 @@ fastmail-cli forward EMAIL_ID --to ADDR [--body STR] [--cc] [--bcc] [--from IDEN
 ```bash
 fastmail-cli move EMAIL_ID --to MAILBOX
 fastmail-cli mark-read EMAIL_ID [--unread]
-fastmail-cli spam EMAIL_ID [-y]
+fastmail-cli spam EMAIL_ID
 ```
 
 ### Attachments

--- a/.claude/skills/fastmail/compose.md
+++ b/.claude/skills/fastmail/compose.md
@@ -1,9 +1,19 @@
 ---
 name: fastmail/compose
-description: fastmail-cli send, reply, forward, draft — flags, identities, and compose patterns
+description: fastmail-cli send, reply, forward, draft — flags, identities, and compose patterns. REQUIRES USER CONFIRMATION before sending.
+allowed-tools: Bash
 ---
 
 # fastmail-cli — Compose (Send / Reply / Forward / Draft)
+
+## Safety Rules
+
+1. **Before executing `send`, `reply`, or `forward` without `--draft`**: Display the full command to the user — including all recipients, subject, and body text — and ask "Should I send this?" Wait for explicit yes.
+2. **Ambiguous intent → use `--draft`**: If the user says "write a reply", "draft an email", or "compose a message", always use `--draft`. Only omit `--draft` when the user clearly wants to send ("send this to Bob", "reply saying yes").
+3. **Never add recipients the user did not specify.**
+4. **Never send bulk emails.** Do not loop over recipient lists or search results to send multiple messages.
+
+---
 
 ## Identities
 

--- a/src/commands/forward.rs
+++ b/src/commands/forward.rs
@@ -1,11 +1,11 @@
-use crate::jmap::{ComposeParams, authenticated_client};
+use crate::jmap::{ComposeParams, MessageBody, authenticated_client};
 use crate::models::Output;
 use crate::util::parse_addresses;
 
 pub async fn forward(
     email_id: &str,
     to: &str,
-    body: &str,
+    message_body: MessageBody,
     params: ComposeParams<'_>,
 ) -> anyhow::Result<()> {
     let client = authenticated_client().await?;
@@ -14,7 +14,7 @@ pub async fn forward(
     let original = client.get_email(email_id).await?;
 
     let new_email_id = client
-        .forward_email(&original, parse_addresses(to), body, params)
+        .forward_email(&original, parse_addresses(to), message_body, params)
         .await?;
 
     #[derive(serde::Serialize)]

--- a/src/commands/reply.rs
+++ b/src/commands/reply.rs
@@ -1,9 +1,9 @@
-use crate::jmap::{ComposeParams, authenticated_client};
+use crate::jmap::{ComposeParams, MessageBody, authenticated_client};
 use crate::models::Output;
 
 pub async fn reply(
     email_id: &str,
-    body: &str,
+    message_body: MessageBody,
     reply_all: bool,
     params: ComposeParams<'_>,
 ) -> anyhow::Result<()> {
@@ -13,7 +13,7 @@ pub async fn reply(
     let original = client.get_email(email_id).await?;
 
     let new_email_id = client
-        .reply_email(&original, body, reply_all, params)
+        .reply_email(&original, message_body, reply_all, params)
         .await?;
 
     #[derive(serde::Serialize)]

--- a/src/commands/send.rs
+++ b/src/commands/send.rs
@@ -1,11 +1,11 @@
-use crate::jmap::{ComposeParams, authenticated_client};
+use crate::jmap::{ComposeParams, MessageBody, authenticated_client};
 use crate::models::Output;
 use crate::util::parse_addresses;
 
 pub async fn send(
     to: &str,
     subject: &str,
-    body: &str,
+    message_body: MessageBody,
     reply_to: Option<&str>,
     params: ComposeParams<'_>,
 ) -> anyhow::Result<()> {
@@ -13,7 +13,7 @@ pub async fn send(
     let draft = params.draft;
 
     let email_id = client
-        .send_email(parse_addresses(to), subject, body, reply_to, params)
+        .send_email(parse_addresses(to), subject, message_body, reply_to, params)
         .await?;
 
     #[derive(serde::Serialize)]

--- a/src/jmap/mod.rs
+++ b/src/jmap/mod.rs
@@ -42,6 +42,63 @@ pub struct ComposeParams<'a> {
     pub draft: bool,
 }
 
+/// A file attachment that has been uploaded as a JMAP blob
+#[derive(Debug, Clone)]
+pub struct UploadedAttachment {
+    pub blob_id: String,
+    pub name: String,
+    pub content_type: String,
+    pub size: u64,
+}
+
+/// Structured email body with optional HTML alternative and attachments
+pub struct MessageBody {
+    pub text: String,
+    pub html: Option<String>,
+    pub attachments: Vec<UploadedAttachment>,
+}
+
+impl MessageBody {
+    /// Apply body parts to a JMAP Email/set create object
+    fn apply_to_email(&self, email_create: &mut HashMap<String, Value>) {
+        let mut body_values = json!({
+            "text": { "value": self.text, "charset": "utf-8" }
+        });
+        email_create.insert(
+            "textBody".into(),
+            json!([{ "partId": "text", "type": "text/plain" }]),
+        );
+
+        if let Some(ref html) = self.html {
+            body_values["html"] = json!({ "value": html, "charset": "utf-8" });
+            email_create.insert(
+                "htmlBody".into(),
+                json!([{ "partId": "html", "type": "text/html" }]),
+            );
+        }
+
+        email_create.insert("bodyValues".into(), body_values);
+
+        if !self.attachments.is_empty() {
+            email_create.insert(
+                "attachments".into(),
+                json!(
+                    self.attachments
+                        .iter()
+                        .map(|a| json!({
+                            "blobId": a.blob_id,
+                            "type": a.content_type,
+                            "name": a.name,
+                            "disposition": "attachment",
+                            "size": a.size,
+                        }))
+                        .collect::<Vec<_>>()
+                ),
+            );
+        }
+    }
+}
+
 /// Resolved context for a compose operation
 struct ComposeContext {
     account_id: String,
@@ -693,12 +750,12 @@ impl JmapClient {
             })
     }
 
-    #[instrument(skip(self, body, params))]
+    #[instrument(skip(self, message_body, params))]
     pub async fn send_email(
         &self,
         to: Vec<EmailAddress>,
         subject: &str,
-        body: &str,
+        message_body: MessageBody,
         in_reply_to: Option<&str>,
         params: ComposeParams<'_>,
     ) -> Result<String> {
@@ -739,14 +796,7 @@ impl JmapClient {
             );
         }
         email_create.insert("subject".into(), json!(subject));
-        email_create.insert(
-            "bodyValues".into(),
-            json!({ "body": { "value": body, "charset": "utf-8" } }),
-        );
-        email_create.insert(
-            "textBody".into(),
-            json!([{ "partId": "body", "type": "text/plain" }]),
-        );
+        message_body.apply_to_email(&mut email_create);
         if let Some(reply_id) = in_reply_to {
             email_create.insert("inReplyTo".into(), json!([reply_id]));
         }
@@ -846,12 +896,57 @@ impl JmapClient {
         Ok(bytes.to_vec())
     }
 
+    /// Upload binary data as a JMAP blob, returning the blob ID
+    #[instrument(skip(self, data))]
+    pub async fn upload_blob(&self, data: &[u8], content_type: &str) -> Result<UploadedAttachment> {
+        let session = self.session()?;
+        let account_id = session
+            .primary_account_id()
+            .ok_or_else(|| Error::Config("No primary account".into()))?;
+
+        let url = session.upload_url.replace("{accountId}", account_id);
+
+        debug!(url = %url, content_type = %content_type, size = data.len(), "Uploading blob");
+        let resp = self
+            .client
+            .post(&url)
+            .bearer_auth(&self.token)
+            .header("Content-Type", content_type)
+            .body(data.to_vec())
+            .send()
+            .await?;
+
+        match resp.status().as_u16() {
+            401 => return Err(Error::InvalidToken("Token expired or invalid".into())),
+            429 => return Err(Error::RateLimited),
+            500..=599 => return Err(Error::Server(format!("Server error: {}", resp.status()))),
+            _ => {}
+        }
+
+        #[derive(Deserialize)]
+        struct UploadResponse {
+            #[serde(rename = "blobId")]
+            blob_id: String,
+            size: u64,
+        }
+
+        let upload: UploadResponse = resp.json().await?;
+        debug!(blob_id = %upload.blob_id, size = upload.size, "Blob uploaded");
+
+        Ok(UploadedAttachment {
+            blob_id: upload.blob_id,
+            name: String::new(),
+            content_type: content_type.to_string(),
+            size: upload.size,
+        })
+    }
+
     /// Send a reply to an existing email with proper threading headers
-    #[instrument(skip(self, body, params))]
+    #[instrument(skip(self, message_body, params))]
     pub async fn reply_email(
         &self,
         original: &Email,
-        body: &str,
+        message_body: MessageBody,
         reply_all: bool,
         params: ComposeParams<'_>,
     ) -> Result<String> {
@@ -947,14 +1042,7 @@ impl JmapClient {
             );
         }
         email_create.insert("subject".into(), json!(subject));
-        email_create.insert(
-            "bodyValues".into(),
-            json!({ "body": { "value": body, "charset": "utf-8" } }),
-        );
-        email_create.insert(
-            "textBody".into(),
-            json!([{ "partId": "body", "type": "text/plain" }]),
-        );
+        message_body.apply_to_email(&mut email_create);
 
         // Threading headers
         if let Some(ref msg_id) = original.message_id {
@@ -972,12 +1060,12 @@ impl JmapClient {
     }
 
     /// Forward an email with proper attribution
-    #[instrument(skip(self, body, params))]
+    #[instrument(skip(self, message_body, params))]
     pub async fn forward_email(
         &self,
         original: &Email,
         to: Vec<EmailAddress>,
-        body: &str,
+        message_body: MessageBody,
         params: ComposeParams<'_>,
     ) -> Result<String> {
         let ctx = self.prepare_compose(params.from, params.draft).await?;
@@ -1016,14 +1104,28 @@ impl JmapClient {
 
         let date = original.received_at.as_deref().unwrap_or("unknown date");
 
-        let full_body = format!(
-            "{}\n\n---------- Forwarded message ---------\nFrom: {}\nDate: {}\nSubject: {}\n\n{}",
-            body,
+        let fwd_attribution = format!(
+            "\n\n---------- Forwarded message ---------\nFrom: {}\nDate: {}\nSubject: {}\n\n{}",
             sender,
             date,
             original.subject.as_deref().unwrap_or(""),
             original_body
         );
+
+        let full_body = MessageBody {
+            text: format!("{}{}", message_body.text, fwd_attribution),
+            html: message_body.html.map(|h| {
+                format!(
+                    "{}<br><br><hr><b>---------- Forwarded message ---------</b><br>From: {}<br>Date: {}<br>Subject: {}<br><br>{}",
+                    h,
+                    sender,
+                    date,
+                    original.subject.as_deref().unwrap_or(""),
+                    original_body
+                )
+            }),
+            attachments: message_body.attachments,
+        };
 
         let mut email_create: HashMap<String, Value> = HashMap::new();
         ctx.apply_to_email(&mut email_create);
@@ -1060,14 +1162,7 @@ impl JmapClient {
             );
         }
         email_create.insert("subject".into(), json!(subject));
-        email_create.insert(
-            "bodyValues".into(),
-            json!({ "body": { "value": full_body, "charset": "utf-8" } }),
-        );
-        email_create.insert(
-            "textBody".into(),
-            json!([{ "partId": "body", "type": "text/plain" }]),
-        );
+        full_body.apply_to_email(&mut email_create);
 
         let responses = self.request(ctx.build_method_calls(email_create)).await?;
         let email_id = Self::parse_email_create_response(&responses)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,54 @@ use clap::{CommandFactory, Parser, Subcommand};
 use clap_complete::{Shell, generate};
 use models::Output;
 use std::io;
+use std::path::Path;
 use tracing_subscriber::EnvFilter;
+
+/// Resolve HTML content from --html-body or --html-file, and upload any attachments
+async fn build_message_body(
+    body: String,
+    html_body: Option<String>,
+    html_file: Option<String>,
+    attachments: Vec<String>,
+) -> anyhow::Result<jmap::MessageBody> {
+    let html = match (html_body, html_file) {
+        (Some(h), _) => Some(h),
+        (_, Some(path)) => Some(
+            tokio::fs::read_to_string(&path)
+                .await
+                .map_err(|e| anyhow::anyhow!("Failed to read HTML file '{}': {}", path, e))?,
+        ),
+        _ => None,
+    };
+
+    let uploaded = if attachments.is_empty() {
+        vec![]
+    } else {
+        let client = jmap::authenticated_client().await?;
+        let mut uploaded = Vec::with_capacity(attachments.len());
+        for path_str in &attachments {
+            let path = Path::new(path_str);
+            let data = tokio::fs::read(path)
+                .await
+                .map_err(|e| anyhow::anyhow!("Failed to read attachment '{}': {}", path_str, e))?;
+            let filename = path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or("attachment");
+            let content_type = util::mime_from_filename(filename);
+            let mut att = client.upload_blob(&data, &content_type).await?;
+            att.name = filename.to_string();
+            uploaded.push(att);
+        }
+        uploaded
+    };
+
+    Ok(jmap::MessageBody {
+        text: body,
+        html,
+        attachments: uploaded,
+    })
+}
 
 #[derive(Parser)]
 #[command(name = "fastmail-cli")]
@@ -126,6 +173,18 @@ enum Commands {
         #[arg(long)]
         body: String,
 
+        /// HTML body (creates multipart/alternative with plain text)
+        #[arg(long, conflicts_with = "html_file")]
+        html_body: Option<String>,
+
+        /// Path to HTML file for email body (creates multipart/alternative with plain text)
+        #[arg(long, conflicts_with = "html_body")]
+        html_file: Option<String>,
+
+        /// File attachment(s) — can be specified multiple times
+        #[arg(long)]
+        attachment: Vec<String>,
+
         /// CC recipient(s), comma-separated
         #[arg(long)]
         cc: Option<String>,
@@ -204,6 +263,18 @@ enum Commands {
         #[arg(long)]
         body: String,
 
+        /// HTML reply body (creates multipart/alternative with plain text)
+        #[arg(long, conflicts_with = "html_file")]
+        html_body: Option<String>,
+
+        /// Path to HTML file for reply body (creates multipart/alternative with plain text)
+        #[arg(long, conflicts_with = "html_body")]
+        html_file: Option<String>,
+
+        /// File attachment(s) — can be specified multiple times
+        #[arg(long)]
+        attachment: Vec<String>,
+
         /// Reply to all recipients
         #[arg(long)]
         all: bool,
@@ -237,6 +308,18 @@ enum Commands {
         /// Message to include before forwarded content
         #[arg(long, default_value = "")]
         body: String,
+
+        /// HTML message to include before forwarded content (creates multipart/alternative)
+        #[arg(long, conflicts_with = "html_file")]
+        html_body: Option<String>,
+
+        /// Path to HTML file for message before forwarded content
+        #[arg(long, conflicts_with = "html_body")]
+        html_file: Option<String>,
+
+        /// File attachment(s) — can be specified multiple times
+        #[arg(long)]
+        attachment: Vec<String>,
 
         /// CC recipient(s), comma-separated
         #[arg(long)]
@@ -416,27 +499,35 @@ async fn main() {
             to,
             subject,
             body,
+            html_body,
+            html_file,
+            attachment,
             cc,
             bcc,
             reply_to,
             from,
             draft,
         } => {
-            commands::send(
-                &to,
-                &subject,
-                &body,
-                reply_to.as_deref(),
-                jmap::ComposeParams {
-                    cc: cc.as_deref().map(util::parse_addresses).unwrap_or_default(),
-                    bcc: bcc
-                        .as_deref()
-                        .map(util::parse_addresses)
-                        .unwrap_or_default(),
-                    from: from.as_deref(),
-                    draft,
-                },
-            )
+            async {
+                let message_body =
+                    build_message_body(body, html_body, html_file, attachment).await?;
+                commands::send(
+                    &to,
+                    &subject,
+                    message_body,
+                    reply_to.as_deref(),
+                    jmap::ComposeParams {
+                        cc: cc.as_deref().map(util::parse_addresses).unwrap_or_default(),
+                        bcc: bcc
+                            .as_deref()
+                            .map(util::parse_addresses)
+                            .unwrap_or_default(),
+                        from: from.as_deref(),
+                        draft,
+                    },
+                )
+                .await
+            }
             .await
         }
 
@@ -470,26 +561,34 @@ async fn main() {
         Commands::Reply {
             email_id,
             body,
+            html_body,
+            html_file,
+            attachment,
             all,
             cc,
             bcc,
             from,
             draft,
         } => {
-            commands::reply(
-                &email_id,
-                &body,
-                all,
-                jmap::ComposeParams {
-                    cc: cc.as_deref().map(util::parse_addresses).unwrap_or_default(),
-                    bcc: bcc
-                        .as_deref()
-                        .map(util::parse_addresses)
-                        .unwrap_or_default(),
-                    from: from.as_deref(),
-                    draft,
-                },
-            )
+            async {
+                let message_body =
+                    build_message_body(body, html_body, html_file, attachment).await?;
+                commands::reply(
+                    &email_id,
+                    message_body,
+                    all,
+                    jmap::ComposeParams {
+                        cc: cc.as_deref().map(util::parse_addresses).unwrap_or_default(),
+                        bcc: bcc
+                            .as_deref()
+                            .map(util::parse_addresses)
+                            .unwrap_or_default(),
+                        from: from.as_deref(),
+                        draft,
+                    },
+                )
+                .await
+            }
             .await
         }
 
@@ -497,25 +596,33 @@ async fn main() {
             email_id,
             to,
             body,
+            html_body,
+            html_file,
+            attachment,
             cc,
             bcc,
             from,
             draft,
         } => {
-            commands::forward(
-                &email_id,
-                &to,
-                &body,
-                jmap::ComposeParams {
-                    cc: cc.as_deref().map(util::parse_addresses).unwrap_or_default(),
-                    bcc: bcc
-                        .as_deref()
-                        .map(util::parse_addresses)
-                        .unwrap_or_default(),
-                    from: from.as_deref(),
-                    draft,
-                },
-            )
+            async {
+                let message_body =
+                    build_message_body(body, html_body, html_file, attachment).await?;
+                commands::forward(
+                    &email_id,
+                    &to,
+                    message_body,
+                    jmap::ComposeParams {
+                        cc: cc.as_deref().map(util::parse_addresses).unwrap_or_default(),
+                        bcc: bcc
+                            .as_deref()
+                            .map(util::parse_addresses)
+                            .unwrap_or_default(),
+                        from: from.as_deref(),
+                        draft,
+                    },
+                )
+                .await
+            }
             .await
         }
 

--- a/src/mcp/graphql/mutation.rs
+++ b/src/mcp/graphql/mutation.rs
@@ -21,6 +21,8 @@ impl MutationRoot {
         #[graphql(desc = "Recipient email address(es), comma-separated")] to: String,
         #[graphql(desc = "Email subject line")] subject: String,
         #[graphql(desc = "Email body text")] body: String,
+        #[graphql(desc = "Optional HTML body (creates multipart/alternative with plain text)")]
+        html_body: Option<String>,
         #[graphql(desc = "CC recipients, comma-separated")] cc: Option<String>,
         #[graphql(desc = "BCC recipients (hidden), comma-separated")] bcc: Option<String>,
         #[graphql(desc = "Send from a specific identity/email address")] from: Option<String>,
@@ -44,11 +46,17 @@ impl MutationRoot {
         let client = ctx.data::<tokio::sync::Mutex<crate::jmap::JmapClient>>()?;
         let client = client.lock().await;
 
+        let message_body = crate::jmap::MessageBody {
+            text: body,
+            html: html_body,
+            attachments: vec![],
+        };
+
         match client
             .send_email(
                 to_addrs,
                 &subject,
-                &body,
+                message_body,
                 None,
                 crate::jmap::ComposeParams {
                     cc: cc_addrs,
@@ -82,6 +90,10 @@ impl MutationRoot {
         action: SendAction,
         #[graphql(desc = "The email ID to reply to")] email_id: String,
         #[graphql(desc = "Reply body text (your response, without quoting original)")] body: String,
+        #[graphql(
+            desc = "Optional HTML reply body (creates multipart/alternative with plain text)"
+        )]
+        html_body: Option<String>,
         #[graphql(desc = "Reply to all recipients")] all: Option<bool>,
         #[graphql(desc = "CC recipients, comma-separated")] cc: Option<String>,
         #[graphql(desc = "BCC recipients, comma-separated")] bcc: Option<String>,
@@ -139,10 +151,16 @@ impl MutationRoot {
         }
 
         let draft = matches!(action, SendAction::Draft);
+        let message_body = crate::jmap::MessageBody {
+            text: body,
+            html: html_body,
+            attachments: vec![],
+        };
+
         match client
             .reply_email(
                 &original,
-                &body,
+                message_body,
                 reply_all,
                 crate::jmap::ComposeParams {
                     cc: cc_addrs,
@@ -177,6 +195,9 @@ impl MutationRoot {
         #[graphql(desc = "The email ID to forward")] email_id: String,
         #[graphql(desc = "Recipient email address(es), comma-separated")] to: String,
         #[graphql(desc = "Your message to include above forwarded content")] body: Option<String>,
+        #[graphql(desc = "Optional HTML message above forwarded content")] html_body: Option<
+            String,
+        >,
         #[graphql(desc = "CC recipients, comma-separated")] cc: Option<String>,
         #[graphql(desc = "BCC recipients, comma-separated")] bcc: Option<String>,
         #[graphql(desc = "Send from a specific identity/email address")] from: Option<String>,
@@ -238,11 +259,17 @@ impl MutationRoot {
         }
 
         let draft = matches!(action, SendAction::Draft);
+        let message_body = crate::jmap::MessageBody {
+            text: body_str.to_string(),
+            html: html_body,
+            attachments: vec![],
+        };
+
         match client
             .forward_email(
                 &original,
                 to_addrs,
-                body_str,
+                message_body,
                 crate::jmap::ComposeParams {
                     cc: cc_addrs,
                     bcc: bcc_addrs,

--- a/src/util.rs
+++ b/src/util.rs
@@ -76,7 +76,7 @@ fn is_image_extension(filename: &str) -> bool {
 }
 
 /// Infer MIME type from filename extension for documents
-fn mime_from_filename(filename: &str) -> String {
+pub fn mime_from_filename(filename: &str) -> String {
     let ext = Path::new(filename)
         .extension()
         .and_then(|e| e.to_str())


### PR DESCRIPTION
## Summary

- Adds `--html-body`, `--html-file`, and `--attachment` flags to `send`, `reply`, and `forward` commands
- JMAP server constructs `multipart/alternative` automatically when both `textBody` and `htmlBody` are provided
- Attachments are uploaded as blobs via the JMAP upload endpoint, then referenced by `blobId` in the `attachments` array
- Refactors body construction into a shared `MessageBody` struct, replacing duplicated inline `text/plain` logic across all three compose methods
- Adds `upload_blob()` to `JmapClient` using `Session.upload_url`
- Existing `--body` plain text syntax is fully backward compatible

## New CLI flags

| Flag | Description |
|------|-------------|
| `--html-body "string"` | Inline HTML body (creates multipart/alternative with plain text) |
| `--html-file path` | Read HTML body from file (mutually exclusive with `--html-body`) |
| `--attachment path` | File attachment, repeatable (uploads blob, attaches to email) |

## Test plan

- [x] `cargo fmt && cargo clippy -- -D warnings && cargo test` — all 33 tests pass
- [x] `fastmail-cli send --to ... --subject ... --body "text"` — plain text only, identical to before
- [x] `fastmail-cli send --to ... --subject ... --body "text" --html-body "<p>html</p>"` — multipart/alternative received
- [x] `fastmail-cli reply <id> --body "text"` — plain text reply threads correctly
- [x] `fastmail-cli reply <id> --body "text" --html-body "<p>html</p>"` — HTML reply threads correctly
- [x] `fastmail-cli forward <id> --to ... --body "text"` — plain text forward with attribution
- [x] `fastmail-cli forward <id> --to ... --body "text" --html-body "<p>html</p>"` — HTML forward with attribution
- [x] `--html-body` and `--html-file` conflict correctly (clap error)
- [x] GraphQL `sendEmail`, `replyToEmail`, `forwardEmail` mutations accept optional `htmlBody` parameter