### PR TITLE
chore: bump rmcp 0.12 -> 1.5 + schemars 0.8 -> 1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1284,7 +1284,7 @@ dependencies = [
  "reqwest",
  "rmcp",
  "roxmltree",
- "schemars 0.8.22",
+ "schemars",
  "serde",
  "serde_json",
  "tempfile",
@@ -3427,9 +3427,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.12.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528d42f8176e6e5e71ea69182b17d1d0a19a6b3b894b564678b74cd7cab13cfa"
+checksum = "67d69668de0b0ccd9cc435f700f3b39a7861863cf37a15e1f304ea78688a4826"
 dependencies = [
  "async-trait",
  "base64",
@@ -3438,7 +3438,7 @@ dependencies = [
  "pastey 0.2.1",
  "pin-project-lite",
  "rmcp-macros",
- "schemars 1.2.1",
+ "schemars",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -3449,9 +3449,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.12.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3f81daaa494eb8e985c9462f7d6ce1ab05e5299f48aafd76cdd3d8b060e6f59"
+checksum = "48fdc01c81097b0aed18633e676e269fefa3a78ec1df56b4fe597c1241b92025"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -3620,18 +3620,6 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
-dependencies = [
- "dyn-clone",
- "schemars_derive 0.8.22",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "schemars"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
@@ -3639,21 +3627,9 @@ dependencies = [
  "chrono",
  "dyn-clone",
  "ref-cast",
- "schemars_derive 1.2.1",
+ "schemars_derive",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "schemars_derive"
-version = "0.8.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde_derive_internals",
- "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,8 @@ reqwest = { version = "0.13.1", default-features = false, features = [
   "json",
   "rustls"
 ] }
-rmcp = { version = "0.12", features = ["server", "transport-io"] }
-schemars = "0.8"
+rmcp = { version = "1", features = ["server", "transport-io"] }
+schemars = "1"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 thiserror = "2.0.17"

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -39,6 +39,7 @@ pub struct GraphqlRequest {
 #[derive(Clone)]
 pub struct FastmailMcp {
     schema: Arc<FastmailSchema>,
+    #[allow(dead_code)] // referenced by #[tool_handler] macro expansion
     tool_router: ToolRouter<Self>,
 }
 
@@ -109,17 +110,14 @@ impl FastmailMcp {
 #[tool_handler]
 impl ServerHandler for FastmailMcp {
     fn get_info(&self) -> ServerInfo {
-        ServerInfo {
-            protocol_version: rmcp::model::ProtocolVersion::V_2024_11_05,
-            capabilities: ServerCapabilities::builder().enable_tools().build(),
-            server_info: Implementation {
-                name: "fastmail-cli".to_string(),
-                title: Some("Fastmail MCP Server".to_string()),
-                version: env!("CARGO_PKG_VERSION").to_string(),
-                icons: None,
-                website_url: Some("https://github.com/radiosilence/fastmail-cli".to_string()),
-            },
-            instructions: Some(
+        let server_info = Implementation::new("fastmail-cli", env!("CARGO_PKG_VERSION"))
+            .with_title("Fastmail MCP Server")
+            .with_website_url("https://github.com/radiosilence/fastmail-cli");
+
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+            .with_protocol_version(rmcp::model::ProtocolVersion::V_2024_11_05)
+            .with_server_info(server_info)
+            .with_instructions(
                 "Fastmail MCP Server — GraphQL interface for email operations.\n\n\
                 ## Getting Started\n\
                 1. Call `schema_sdl` to get the full GraphQL schema\n\
@@ -145,10 +143,8 @@ impl ServerHandler for FastmailMcp {
                 ## Safety Rules\n\
                 - NEVER send without showing preview first\n\
                 - NEVER confirm send without explicit user approval\n\
-                - mark_as_spam affects future filtering — always preview first"
-                    .to_string(),
-            ),
-        }
+                - mark_as_spam affects future filtering — always preview first",
+            )
     }
 }
 


### PR DESCRIPTION
## Summary

Two bumps that have to travel together — \`rmcp\` re-exports \`schemars\`, so a mismatched pair breaks the derive.

### \`rmcp\` 0.12 → 1.5

The 1.0 release added \`#[non_exhaustive]\` to model structs, so \`ServerInfo { ... }\` and \`Implementation { ... }\` struct-literal construction no longer compiles. Rewrote \`get_info()\` using the builder API that\x27s been there all along:

\`\`\`rust
let server_info = Implementation::new(\"fastmail-cli\", env!(\"CARGO_PKG_VERSION\"))
    .with_title(\"Fastmail MCP Server\")
    .with_website_url(\"https://github.com/radiosilence/fastmail-cli\");

ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
    .with_protocol_version(rmcp::model::ProtocolVersion::V_2024_11_05)
    .with_server_info(server_info)
    .with_instructions(...)
\`\`\`

Reads cleaner than the old literal form. The proc-macros (\`#[tool]\`, \`#[tool_router]\`, \`#[tool_handler]\`) are unchanged in surface.

### \`schemars\` 0.8 → 1.2

One derive site (\`GraphqlRequest\`). No API change hits our usage; the \`visit\` module / \`RootSchema\` removals don\x27t touch us.

### Dead-code warning

Added \`#[allow(dead_code)]\` on \`tool_router: ToolRouter<Self>\`. The \`#[tool_handler]\` proc-macro references it in its expansion, but dead-code analysis can\x27t see through the macro — same pattern in rmcp\x27s own tests.

## Test plan

- [x] \`cargo test\` — 89 passing
- [x] \`cargo clippy --all-targets -- -D warnings\` — clean (including Rust 1.95 lints)
- [x] \`cargo fmt -- --check\` — clean
- [ ] CI green
- [ ] Smoke test: \`fastmail-cli mcp\` starts, Claude Desktop can hit \`schema_sdl\` and \`graphql\` tools (MCP integration only verified once deployed — local \`cargo test\` doesn\x27t cover the stdio transport path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)