### PR TITLE
release: v2.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.2.2] - 2026-04-18
+
+### Changed
+
+- **NonceStore is now bounded** ([#27](https://github.com/radiosilence/fastmail-cli/pull/27)): 15-minute TTL per nonce and a hard cap of 256 outstanding nonces. Closes [#25](https://github.com/radiosilence/fastmail-cli/issues/25) — follow-up from the v2.2.1 security audit.
+- **Dep bumps**: `kreuzberg` 4.4 → 4.8, `toml` 0.8 → 1.1, `rmcp` 0.12 → 1.5, `schemars` 0.8 → 1.2. The rmcp 1.0 `#[non_exhaustive]` model-struct fallout moved `get_info()` onto the builder API (`ServerInfo::new().with_*()` instead of struct literals) — cleaner read, same behaviour.
+
 ## [2.2.1] - 2026-04-18
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1270,7 +1270,7 @@ dependencies = [
 
 [[package]]
 name = "fastmail-cli"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "anyhow",
  "async-graphql",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fastmail-cli"
-version = "2.2.1"
+version = "2.2.2"
 edition = "2024"
 description = "CLI for Fastmail's JMAP API"
 repository = "https://github.com/radiosilence/fastmail-cli"


### PR DESCRIPTION
## Summary

Cuts v2.2.2 over the bundle of post-v2.2.1 changes:

- **#27** NonceStore cap + TTL (closes #25)
- **#28** kreuzberg 4.4 → 4.8
- **#29** toml 0.8 → 1.1
- **#30** rmcp 0.12 → 1.5 + schemars 0.8 → 1.2

## Test plan

- [x] \`cargo build\` — clean
- [x] Pure Cargo.toml/CHANGELOG bump on top of already-verified main
- [ ] CI green → auto-tags v2.2.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)